### PR TITLE
fix: none reactive query enabled

### DIFF
--- a/packages/core/src/utils/query.ts
+++ b/packages/core/src/utils/query.ts
@@ -1,4 +1,4 @@
-import type { Enabled, Query, QueryClient, QueryKey, QueryKeyHashFunction } from '@tanstack/query-core'
+import type { Query, QueryBooleanOption, QueryClient, QueryKey, QueryKeyHashFunction } from '@tanstack/query-core'
 import { hashKey } from '@tanstack/query-core'
 
 export type OriginQueryEnabledFn<
@@ -24,7 +24,7 @@ export function resolveQueryEnableds<
 >(
 	query: Query<TQueryFnData, TError, TData>,
 	enableds: (
-		| Enabled<TQueryFnData, TError, TData>
+		| QueryBooleanOption<TQueryFnData, TError, TData>
 		| (() => boolean | undefined) | undefined
 	)[],
 ): boolean {

--- a/packages/svelte/src/auth/authenticated.svelte.test.ts
+++ b/packages/svelte/src/auth/authenticated.svelte.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useAuthenticated } from './authenticated.svelte'
+
+const mocks = vi.hoisted(() => ({
+	createQuery: vi.fn(),
+	createQueryEnabledFn: vi.fn(),
+	createQueryFn: vi.fn(),
+	createQueryKey: vi.fn(),
+	useAuthContext: vi.fn(),
+	useQueryCallbacks: vi.fn(),
+	useQueryClientContext: vi.fn(),
+}))
+
+vi.mock('@ginjou/core', () => ({
+	CheckAuth: {
+		createQueryEnabledFn: mocks.createQueryEnabledFn,
+		createQueryFn: mocks.createQueryFn,
+		createQueryKey: mocks.createQueryKey,
+	},
+}))
+
+vi.mock('@tanstack/svelte-query', () => ({
+	createQuery: mocks.createQuery,
+}))
+
+vi.mock('tanstack-query-callbacks/svelte', () => ({
+	useQueryCallbacks: mocks.useQueryCallbacks,
+}))
+
+vi.mock('./auth', () => ({
+	useAuthContext: mocks.useAuthContext,
+}))
+
+vi.mock('../query', () => ({
+	useQueryClientContext: mocks.useQueryClientContext,
+}))
+
+describe('useAuthenticated', () => {
+	beforeEach(() => {
+		for (const mock of Object.values(mocks))
+			mock.mockReset()
+
+		mocks.createQuery.mockReturnValue({})
+		mocks.createQueryEnabledFn.mockImplementation(({ getEnabled }) => {
+			return () => getEnabled() !== false
+		})
+		mocks.createQueryFn.mockReturnValue(vi.fn())
+		mocks.createQueryKey.mockReturnValue(['auth', 'check'])
+		mocks.useAuthContext.mockReturnValue({})
+		mocks.useQueryClientContext.mockReturnValue({})
+	})
+
+	it('should preserve the previous enabled snapshot when accessor props change', () => {
+		let isEnabled = $state(false)
+
+		useAuthenticated(() => ({
+			queryOptions: {
+				enabled: isEnabled,
+			},
+		}))
+
+		const getQueryOptions = mocks.createQuery.mock.calls[0][0]
+		const disabledOptions = getQueryOptions()
+		expect(disabledOptions.enabled()).toBe(false)
+
+		isEnabled = true
+		const enabledOptions = getQueryOptions()
+
+		expect(enabledOptions.enabled()).toBe(true)
+		expect(disabledOptions.enabled()).toBe(false)
+	})
+})

--- a/packages/svelte/src/auth/authenticated.svelte.ts
+++ b/packages/svelte/src/auth/authenticated.svelte.ts
@@ -49,9 +49,12 @@ export function useAuthenticated<
 		auth,
 		getParams: () => resolvedProps?.params,
 	})
-	const enabledFn = CheckAuth.createQueryEnabledFn({
-		getEnabled: () => resolvedProps?.queryOptions?.enabled,
-		getAuth: () => auth,
+	const enabledFn = $derived.by(() => {
+		const queryOptions = resolvedProps?.queryOptions
+		return CheckAuth.createQueryEnabledFn({
+			getEnabled: () => queryOptions?.enabled,
+			getAuth: () => auth,
+		})
 	})
 
 	const query = createQuery<CheckAuthResult, TError>(

--- a/packages/svelte/src/auth/identity.svelte.test.ts
+++ b/packages/svelte/src/auth/identity.svelte.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useGetIdentity } from './identity.svelte'
+
+const mocks = vi.hoisted(() => ({
+	createQuery: vi.fn(),
+	createQueryEnabledFn: vi.fn(),
+	createQueryFn: vi.fn(),
+	createQueryKey: vi.fn(),
+	useAuthContext: vi.fn(),
+	useQueryCallbacks: vi.fn(),
+	useQueryClientContext: vi.fn(),
+}))
+
+vi.mock('@ginjou/core', () => ({
+	Identity: {
+		createQueryEnabledFn: mocks.createQueryEnabledFn,
+		createQueryFn: mocks.createQueryFn,
+		createQueryKey: mocks.createQueryKey,
+	},
+}))
+
+vi.mock('@tanstack/svelte-query', () => ({
+	createQuery: mocks.createQuery,
+}))
+
+vi.mock('tanstack-query-callbacks/svelte', () => ({
+	useQueryCallbacks: mocks.useQueryCallbacks,
+}))
+
+vi.mock('./auth', () => ({
+	useAuthContext: mocks.useAuthContext,
+}))
+
+vi.mock('../query', () => ({
+	useQueryClientContext: mocks.useQueryClientContext,
+}))
+
+describe('useGetIdentity', () => {
+	beforeEach(() => {
+		for (const mock of Object.values(mocks))
+			mock.mockReset()
+
+		mocks.createQuery.mockReturnValue({})
+		mocks.createQueryEnabledFn.mockImplementation(({ getEnabled }) => {
+			return () => getEnabled() !== false
+		})
+		mocks.createQueryFn.mockReturnValue(vi.fn())
+		mocks.createQueryKey.mockReturnValue(['auth', 'identity'])
+		mocks.useAuthContext.mockReturnValue({})
+		mocks.useQueryClientContext.mockReturnValue({})
+	})
+
+	it('should preserve the previous enabled snapshot when accessor props change', () => {
+		let isEnabled = $state(false)
+
+		useGetIdentity(() => ({
+			queryOptions: {
+				enabled: isEnabled,
+			},
+		}))
+
+		const getQueryOptions = mocks.createQuery.mock.calls[0][0]
+		const disabledOptions = getQueryOptions()
+		expect(disabledOptions.enabled()).toBe(false)
+
+		isEnabled = true
+		const enabledOptions = getQueryOptions()
+
+		expect(enabledOptions.enabled()).toBe(true)
+		expect(disabledOptions.enabled()).toBe(false)
+	})
+})

--- a/packages/svelte/src/auth/identity.svelte.ts
+++ b/packages/svelte/src/auth/identity.svelte.ts
@@ -49,9 +49,12 @@ export function useGetIdentity<
 		auth,
 		getParams: () => resolvedProps?.params,
 	})
-	const enabledFn = Identity.createQueryEnabledFn({
-		getEnabled: () => resolvedProps?.queryOptions?.enabled,
-		getAuth: () => auth,
+	const enabledFn = $derived.by(() => {
+		const queryOptions = resolvedProps?.queryOptions
+		return Identity.createQueryEnabledFn({
+			getEnabled: () => queryOptions?.enabled,
+			getAuth: () => auth,
+		})
 	})
 
 	const query = createQuery<GetIdentityResult<TData>, TError>(

--- a/packages/svelte/src/authz/can.svelte.test.ts
+++ b/packages/svelte/src/authz/can.svelte.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useCanAccess } from './can.svelte'
+
+const mocks = vi.hoisted(() => ({
+	createQuery: vi.fn(),
+	createQueryEnabledFn: vi.fn(),
+	createQueryFn: vi.fn(),
+	createQueryKey: vi.fn(),
+	useAuthzContext: vi.fn(),
+	useQueryCallbacks: vi.fn(),
+	useQueryClientContext: vi.fn(),
+}))
+
+vi.mock('@ginjou/core', () => ({
+	CanAccess: {
+		createQueryEnabledFn: mocks.createQueryEnabledFn,
+		createQueryFn: mocks.createQueryFn,
+		createQueryKey: mocks.createQueryKey,
+	},
+}))
+
+vi.mock('@tanstack/svelte-query', () => ({
+	createQuery: mocks.createQuery,
+}))
+
+vi.mock('tanstack-query-callbacks/svelte', () => ({
+	useQueryCallbacks: mocks.useQueryCallbacks,
+}))
+
+vi.mock('./authz', () => ({
+	useAuthzContext: mocks.useAuthzContext,
+}))
+
+vi.mock('../query', () => ({
+	useQueryClientContext: mocks.useQueryClientContext,
+}))
+
+describe('useCanAccess', () => {
+	beforeEach(() => {
+		for (const mock of Object.values(mocks))
+			mock.mockReset()
+
+		mocks.createQuery.mockReturnValue({})
+		mocks.createQueryEnabledFn.mockImplementation(({ getEnabled }) => {
+			return () => getEnabled() !== false
+		})
+		mocks.createQueryFn.mockReturnValue(vi.fn())
+		mocks.createQueryKey.mockReturnValue(['authz', 'can'])
+		mocks.useAuthzContext.mockReturnValue({})
+		mocks.useQueryClientContext.mockReturnValue({})
+	})
+
+	it('should preserve the previous enabled snapshot when accessor props change', () => {
+		let isEnabled = $state(false)
+
+		useCanAccess(() => ({
+			action: 'list',
+			resource: 'posts',
+			queryOptions: {
+				enabled: isEnabled,
+			},
+		}))
+
+		const getQueryOptions = mocks.createQuery.mock.calls[0][0]
+		const disabledOptions = getQueryOptions()
+		expect(disabledOptions.enabled()).toBe(false)
+
+		isEnabled = true
+		const enabledOptions = getQueryOptions()
+
+		expect(enabledOptions.enabled()).toBe(true)
+		expect(disabledOptions.enabled()).toBe(false)
+	})
+})

--- a/packages/svelte/src/authz/can.svelte.ts
+++ b/packages/svelte/src/authz/can.svelte.ts
@@ -50,9 +50,12 @@ export function useCanAccess<
 		authz,
 		getParams: () => params,
 	})
-	const enabledFn = CanAccess.createQueryEnabledFn({
-		getAuthz: () => authz,
-		getEnabled: () => resolvedProps.queryOptions?.enabled,
+	const enabledFn = $derived.by(() => {
+		const queryOptions = resolvedProps.queryOptions
+		return CanAccess.createQueryEnabledFn({
+			getAuthz: () => authz,
+			getEnabled: () => queryOptions?.enabled,
+		})
 	})
 
 	const query = createQuery<AccessCanResult, TError>(

--- a/packages/svelte/src/authz/permissions.svelte.test.ts
+++ b/packages/svelte/src/authz/permissions.svelte.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { usePermissions } from './permissions.svelte'
+
+const mocks = vi.hoisted(() => ({
+	createQuery: vi.fn(),
+	createQueryEnabledFn: vi.fn(),
+	createQueryFn: vi.fn(),
+	createQueryKey: vi.fn(),
+	useAuthzContext: vi.fn(),
+	useQueryCallbacks: vi.fn(),
+	useQueryClientContext: vi.fn(),
+}))
+
+vi.mock('@ginjou/core', () => ({
+	Permissions: {
+		createQueryEnabledFn: mocks.createQueryEnabledFn,
+		createQueryFn: mocks.createQueryFn,
+		createQueryKey: mocks.createQueryKey,
+	},
+}))
+
+vi.mock('@tanstack/svelte-query', () => ({
+	createQuery: mocks.createQuery,
+}))
+
+vi.mock('tanstack-query-callbacks/svelte', () => ({
+	useQueryCallbacks: mocks.useQueryCallbacks,
+}))
+
+vi.mock('./authz', () => ({
+	useAuthzContext: mocks.useAuthzContext,
+}))
+
+vi.mock('../query', () => ({
+	useQueryClientContext: mocks.useQueryClientContext,
+}))
+
+describe('usePermissions', () => {
+	beforeEach(() => {
+		for (const mock of Object.values(mocks))
+			mock.mockReset()
+
+		mocks.createQuery.mockReturnValue({})
+		mocks.createQueryEnabledFn.mockImplementation(({ getEnabled }) => {
+			return () => getEnabled() !== false
+		})
+		mocks.createQueryFn.mockReturnValue(vi.fn())
+		mocks.createQueryKey.mockReturnValue(['authz', 'permissions'])
+		mocks.useAuthzContext.mockReturnValue({})
+		mocks.useQueryClientContext.mockReturnValue({})
+	})
+
+	it('should preserve the previous enabled snapshot when accessor props change', () => {
+		let isEnabled = $state(false)
+
+		usePermissions(() => ({
+			queryOptions: {
+				enabled: isEnabled,
+			},
+		}))
+
+		const getQueryOptions = mocks.createQuery.mock.calls[0][0]
+		const disabledOptions = getQueryOptions()
+		expect(disabledOptions.enabled()).toBe(false)
+
+		isEnabled = true
+		const enabledOptions = getQueryOptions()
+
+		expect(enabledOptions.enabled()).toBe(true)
+		expect(disabledOptions.enabled()).toBe(false)
+	})
+})

--- a/packages/svelte/src/authz/permissions.svelte.ts
+++ b/packages/svelte/src/authz/permissions.svelte.ts
@@ -49,9 +49,12 @@ export function usePermissions<
 		authz,
 		getParams: () => resolvedProps?.params,
 	})
-	const enabledFn = Permissions.createQueryEnabledFn({
-		getAuthz: () => authz,
-		getEnabled: () => resolvedProps?.queryOptions?.enabled,
+	const enabledFn = $derived.by(() => {
+		const queryOptions = resolvedProps?.queryOptions
+		return Permissions.createQueryEnabledFn({
+			getAuthz: () => authz,
+			getEnabled: () => queryOptions?.enabled,
+		})
 	})
 
 	const query = createQuery<GetPermissionsResult<TData>, TError>(

--- a/packages/svelte/src/query/custom.svelte.test.ts
+++ b/packages/svelte/src/query/custom.svelte.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useCustom } from './custom.svelte'
+
+const mocks = vi.hoisted(() => ({
+	createQuery: vi.fn(),
+	createQueryEnabledFn: vi.fn(),
+	createQueryFn: vi.fn(),
+	createQueryKey: vi.fn(),
+	createSuccessHandler: vi.fn(),
+	createErrorHandler: vi.fn(),
+	resolveQueryProps: vi.fn(),
+	useCheckError: vi.fn(),
+	useFetchersContext: vi.fn(),
+	useNotify: vi.fn(),
+	useQueryCallbacks: vi.fn(),
+	useQueryClientContext: vi.fn(),
+	useSubscribe: vi.fn(),
+	useTranslate: vi.fn(),
+}))
+
+vi.mock('@ginjou/core', () => ({
+	RealtimeAction: {
+		Any: 'any',
+	},
+	Custom: {
+		createErrorHandler: mocks.createErrorHandler,
+		createQueryEnabledFn: mocks.createQueryEnabledFn,
+		createQueryFn: mocks.createQueryFn,
+		createQueryKey: mocks.createQueryKey,
+		createSuccessHandler: mocks.createSuccessHandler,
+		resolveQueryProps: mocks.resolveQueryProps,
+	},
+}))
+
+vi.mock('@tanstack/svelte-query', () => ({
+	createQuery: mocks.createQuery,
+}))
+
+vi.mock('tanstack-query-callbacks/svelte', () => ({
+	useQueryCallbacks: mocks.useQueryCallbacks,
+}))
+
+vi.mock('../auth', () => ({
+	useCheckError: mocks.useCheckError,
+}))
+
+vi.mock('../i18n', () => ({
+	useTranslate: mocks.useTranslate,
+}))
+
+vi.mock('../notification', () => ({
+	useNotify: mocks.useNotify,
+}))
+
+vi.mock('../realtime', () => ({
+	useSubscribe: mocks.useSubscribe,
+}))
+
+vi.mock('./fetchers', () => ({
+	useFetchersContext: mocks.useFetchersContext,
+}))
+
+vi.mock('./query-client', () => ({
+	useQueryClientContext: mocks.useQueryClientContext,
+}))
+
+describe('useCustom', () => {
+	beforeEach(() => {
+		for (const mock of Object.values(mocks))
+			mock.mockReset()
+
+		mocks.createErrorHandler.mockReturnValue(vi.fn())
+		mocks.createQuery.mockReturnValue({ data: { data: { id: '1' } } })
+		mocks.createQueryEnabledFn.mockImplementation(({ getEnabled }) => {
+			return () => getEnabled() !== false
+		})
+		mocks.createQueryFn.mockReturnValue(vi.fn())
+		mocks.createQueryKey.mockReturnValue(['custom'])
+		mocks.createSuccessHandler.mockReturnValue(vi.fn())
+		mocks.resolveQueryProps.mockImplementation((props: any) => ({
+			...props,
+			fetcherName: 'default',
+		}))
+		mocks.useCheckError.mockReturnValue({ mutateAsync: vi.fn() })
+		mocks.useFetchersContext.mockReturnValue({})
+		mocks.useNotify.mockReturnValue({})
+		mocks.useQueryClientContext.mockReturnValue({})
+		mocks.useTranslate.mockReturnValue(vi.fn())
+	})
+
+	it('should preserve the previous enabled snapshot when accessor props change', () => {
+		let isEnabled = $state(false)
+
+		useCustom(() => ({
+			url: '/posts/1',
+			method: 'get',
+			queryOptions: {
+				enabled: isEnabled,
+			},
+		}) as any)
+
+		const getQueryOptions = mocks.createQuery.mock.calls[0][0]
+		const disabledOptions = getQueryOptions()
+		expect(disabledOptions.enabled()).toBe(false)
+
+		isEnabled = true
+		const enabledOptions = getQueryOptions()
+
+		expect(enabledOptions.enabled()).toBe(true)
+		expect(disabledOptions.enabled()).toBe(false)
+	})
+})

--- a/packages/svelte/src/query/custom.svelte.ts
+++ b/packages/svelte/src/query/custom.svelte.ts
@@ -84,11 +84,14 @@ export function useCustom<
 		fetchers,
 		getProps: () => queryProps,
 	})
-	const enabledFn = Custom.createQueryEnabledFn<TData, TError, TResultData>({
-		getQueryKey: () => queryKey,
-		getEnabled: () => resolvedProps.queryOptions?.enabled,
-		getQueryOptions: () => resolvedProps.queryOptions,
-		queryClient,
+	const enabledFn = $derived.by(() => {
+		const queryOptions = resolvedProps.queryOptions
+		return Custom.createQueryEnabledFn<TData, TError, TResultData>({
+			getQueryKey: () => queryKey,
+			getEnabled: () => queryOptions?.enabled,
+			getQueryOptions: () => queryOptions,
+			queryClient,
+		})
 	})
 	const handleSuccess = Custom.createSuccessHandler<TData, TResultData, TQuery, TPayload>({
 		notify,

--- a/packages/svelte/src/query/get-infinite-list.svelte.test.ts
+++ b/packages/svelte/src/query/get-infinite-list.svelte.test.ts
@@ -1,8 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { useGetList } from './get-list.svelte'
+import { useGetInfiniteList } from './get-infinite-list.svelte'
 
 const mocks = vi.hoisted(() => ({
-	createQuery: vi.fn(),
+	createInfiniteQuery: vi.fn(),
 	createQueryEnabledFn: vi.fn(),
 	createQueryFn: vi.fn(),
 	createQueryKey: vi.fn(),
@@ -10,6 +10,10 @@ const mocks = vi.hoisted(() => ({
 	createSuccessHandler: vi.fn(),
 	createErrorHandler: vi.fn(),
 	createPlacholerDataFn: vi.fn(),
+	createGetNextPageParamFn: vi.fn(),
+	createGetPreviousPageParamFn: vi.fn(),
+	getInitialPageParam: vi.fn(),
+	getRecords: vi.fn(),
 	getSubscribeChannel: vi.fn(),
 	getSubscribeParams: vi.fn(),
 	resolveQueryProps: vi.fn(),
@@ -30,19 +34,25 @@ vi.mock('@ginjou/core', () => ({
 		Any: 'any',
 	},
 	GetList: {
+		createQueryKey: mocks.createQueryKey,
+		getSubscribeParams: mocks.getSubscribeParams,
+	},
+	GetInfiniteList: {
 		createErrorHandler: mocks.createErrorHandler,
+		createGetNextPageParamFn: mocks.createGetNextPageParamFn,
+		createGetPreviousPageParamFn: mocks.createGetPreviousPageParamFn,
 		createPlacholerDataFn: mocks.createPlacholerDataFn,
 		createQueryEnabledFn: mocks.createQueryEnabledFn,
 		createQueryFn: mocks.createQueryFn,
-		createQueryKey: mocks.createQueryKey,
 		createSuccessHandler: mocks.createSuccessHandler,
-		getSubscribeParams: mocks.getSubscribeParams,
+		getInitialPageParam: mocks.getInitialPageParam,
+		getRecords: mocks.getRecords,
 		resolveQueryProps: mocks.resolveQueryProps,
 	},
 }))
 
 vi.mock('@tanstack/svelte-query', () => ({
-	createQuery: mocks.createQuery,
+	createInfiniteQuery: mocks.createInfiniteQuery,
 }))
 
 vi.mock('tanstack-query-callbacks/svelte', () => ({
@@ -74,100 +84,58 @@ vi.mock('./query-client', () => ({
 	useQueryClientContext: mocks.useQueryClientContext,
 }))
 
-describe('useGetList', () => {
+describe('useGetInfiniteList', () => {
 	beforeEach(() => {
-		mocks.createErrorHandler.mockReset()
-		mocks.createPlacholerDataFn.mockReset()
-		mocks.createQuery.mockReset()
-		mocks.createQueryEnabledFn.mockReset()
-		mocks.createQueryFn.mockReset()
-		mocks.createQueryKey.mockReset()
-		mocks.createSubscribeCallback.mockReset()
-		mocks.createSuccessHandler.mockReset()
-		mocks.getSubscribeChannel.mockReset()
-		mocks.getSubscribeParams.mockReset()
-		mocks.resolveQueryProps.mockReset()
-		mocks.useCheckError.mockReset()
-		mocks.useFetchersContext.mockReset()
-		mocks.useNotify.mockReset()
-		mocks.useQueryCallbacks.mockReset()
-		mocks.useQueryClientContext.mockReset()
-		mocks.useRealtimeOptions.mockReset()
-		mocks.useSubscribe.mockReset()
-		mocks.useTranslate.mockReset()
+		for (const mock of Object.values(mocks))
+			mock.mockReset()
 
 		mocks.createErrorHandler.mockReturnValue(vi.fn())
+		mocks.createGetNextPageParamFn.mockReturnValue(vi.fn())
+		mocks.createGetPreviousPageParamFn.mockReturnValue(vi.fn())
 		mocks.createPlacholerDataFn.mockReturnValue(undefined)
-		mocks.createQuery.mockReturnValue({
-			data: {
-				data: [{ id: '1' }],
-			},
-		})
+		mocks.createInfiniteQuery.mockReturnValue({ data: undefined })
 		mocks.createQueryEnabledFn.mockImplementation(({ getEnabled }) => {
 			return () => getEnabled() !== false
 		})
 		mocks.createQueryFn.mockReturnValue(vi.fn())
-		mocks.createQueryKey.mockReturnValue(['posts'])
+		mocks.createQueryKey.mockReturnValue(['posts', 'getList'])
 		mocks.createSubscribeCallback.mockReturnValue(vi.fn())
 		mocks.createSuccessHandler.mockReturnValue(vi.fn())
+		mocks.getInitialPageParam.mockReturnValue(1)
+		mocks.getRecords.mockReturnValue(undefined)
 		mocks.getSubscribeChannel.mockReturnValue('resources/posts')
-		mocks.getSubscribeParams.mockReturnValue({
-			resource: 'posts',
-			type: 'list',
-		})
-		mocks.resolveQueryProps.mockImplementation(({ resource }: { resource: string }) => ({
+		mocks.getSubscribeParams.mockReturnValue({ resource: 'posts', type: 'list' })
+		mocks.resolveQueryProps.mockImplementation(({ resource, pagination }: { resource: string, pagination: { current: number, perPage: number } }) => ({
 			resource,
+			pagination,
 			fetcherName: 'default',
-			pagination: undefined,
 			sorters: undefined,
 			filters: undefined,
 			meta: undefined,
 		}))
-		mocks.useCheckError.mockReturnValue({
-			mutateAsync: vi.fn(),
-		})
+		mocks.useCheckError.mockReturnValue({ mutateAsync: vi.fn() })
 		mocks.useFetchersContext.mockReturnValue({})
 		mocks.useNotify.mockReturnValue({})
 		mocks.useQueryClientContext.mockReturnValue({})
-		mocks.useRealtimeOptions.mockReturnValue({
-			value: {
-				mode: 'auto',
-			},
-		})
+		mocks.useRealtimeOptions.mockReturnValue({ value: { mode: 'auto' } })
 		mocks.useTranslate.mockReturnValue(vi.fn())
-	})
-
-	it('should expose records accessor and subscribe params', () => {
-		const result = useGetList({
-			resource: 'posts',
-		} as any)
-
-		expect(result.records).toEqual([{ id: '1' }])
-		expect(mocks.useSubscribe).toHaveBeenCalledTimes(1)
-
-		const subscribeProps = mocks.useSubscribe.mock.calls[0][0]()
-		expect(subscribeProps).toMatchObject({
-			channel: 'resources/posts',
-			params: {
-				resource: 'posts',
-				type: 'list',
-			},
-			actions: ['any'],
-		})
-		expect(subscribeProps.enabled()).toBe(true)
 	})
 
 	it('should preserve the previous enabled snapshot when accessor props change', () => {
 		let isEnabled = $state(false)
 
-		useGetList(() => ({
+		useGetInfiniteList(() => ({
 			resource: 'posts',
+			pagination: {
+				current: 1,
+				perPage: 10,
+			},
 			queryOptions: {
 				enabled: isEnabled,
 			},
-		}) as any)
+		}))
 
-		const getQueryOptions = mocks.createQuery.mock.calls[0][0]
+		const getQueryOptions = mocks.createInfiniteQuery.mock.calls[0][0]
 		const disabledOptions = getQueryOptions()
 		expect(disabledOptions.enabled()).toBe(false)
 

--- a/packages/svelte/src/query/get-infinite-list.svelte.ts
+++ b/packages/svelte/src/query/get-infinite-list.svelte.ts
@@ -80,12 +80,15 @@ export function useGetInfiniteList<
 	const initialPageParam = $derived.by(() => GetInfiniteList.getInitialPageParam({
 		props: queryProps,
 	}))
-	const enabledFn = GetInfiniteList.createQueryEnabledFn({
-		getEnabled: () => resolvedProps.queryOptions?.enabled,
-		getQueryKey: () => queryKey,
-		getResource: () => queryProps.resource,
-		getQueryOptions: () => resolvedProps.queryOptions,
-		queryClient,
+	const enabledFn = $derived.by(() => {
+		const queryOptions = resolvedProps.queryOptions
+		return GetInfiniteList.createQueryEnabledFn({
+			getEnabled: () => queryOptions?.enabled,
+			getQueryKey: () => queryKey,
+			getResource: () => queryProps.resource,
+			getQueryOptions: () => queryOptions,
+			queryClient,
+		})
 	})
 	const queryFn = GetInfiniteList.createQueryFn<TData, TPageParam>({
 		getProps,

--- a/packages/svelte/src/query/get-list.svelte.ts
+++ b/packages/svelte/src/query/get-list.svelte.ts
@@ -75,12 +75,15 @@ export function useGetList<
 		meta: extract(resolvedProps.meta),
 	}))
 	const queryKey = $derived.by(() => GetList.createQueryKey<TPageParam>({ props: queryProps }))
-	const enabledFn = GetList.createQueryEnabledFn({
-		getEnabled: () => resolvedProps.queryOptions?.enabled,
-		getQueryKey: () => queryKey,
-		getResource: () => queryProps.resource,
-		getQueryOptions: () => resolvedProps.queryOptions,
-		queryClient,
+	const enabledFn = $derived.by(() => {
+		const queryOptions = resolvedProps.queryOptions
+		return GetList.createQueryEnabledFn({
+			getEnabled: () => queryOptions?.enabled,
+			getQueryKey: () => queryKey,
+			getResource: () => queryProps.resource,
+			getQueryOptions: () => queryOptions,
+			queryClient,
+		})
 	})
 	const queryFn = GetList.createQueryFn<TData, TResultData, TError, TPageParam>({
 		getProps,

--- a/packages/svelte/src/query/get-many.svelte.test.ts
+++ b/packages/svelte/src/query/get-many.svelte.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { useGetList } from './get-list.svelte'
+import { useGetMany } from './get-many.svelte'
 
 const mocks = vi.hoisted(() => ({
 	createQuery: vi.fn(),
@@ -29,7 +29,7 @@ vi.mock('@ginjou/core', () => ({
 	RealtimeAction: {
 		Any: 'any',
 	},
-	GetList: {
+	GetMany: {
 		createErrorHandler: mocks.createErrorHandler,
 		createPlacholerDataFn: mocks.createPlacholerDataFn,
 		createQueryEnabledFn: mocks.createQueryEnabledFn,
@@ -74,98 +74,47 @@ vi.mock('./query-client', () => ({
 	useQueryClientContext: mocks.useQueryClientContext,
 }))
 
-describe('useGetList', () => {
+describe('useGetMany', () => {
 	beforeEach(() => {
-		mocks.createErrorHandler.mockReset()
-		mocks.createPlacholerDataFn.mockReset()
-		mocks.createQuery.mockReset()
-		mocks.createQueryEnabledFn.mockReset()
-		mocks.createQueryFn.mockReset()
-		mocks.createQueryKey.mockReset()
-		mocks.createSubscribeCallback.mockReset()
-		mocks.createSuccessHandler.mockReset()
-		mocks.getSubscribeChannel.mockReset()
-		mocks.getSubscribeParams.mockReset()
-		mocks.resolveQueryProps.mockReset()
-		mocks.useCheckError.mockReset()
-		mocks.useFetchersContext.mockReset()
-		mocks.useNotify.mockReset()
-		mocks.useQueryCallbacks.mockReset()
-		mocks.useQueryClientContext.mockReset()
-		mocks.useRealtimeOptions.mockReset()
-		mocks.useSubscribe.mockReset()
-		mocks.useTranslate.mockReset()
+		for (const mock of Object.values(mocks))
+			mock.mockReset()
 
 		mocks.createErrorHandler.mockReturnValue(vi.fn())
 		mocks.createPlacholerDataFn.mockReturnValue(undefined)
-		mocks.createQuery.mockReturnValue({
-			data: {
-				data: [{ id: '1' }],
-			},
-		})
+		mocks.createQuery.mockReturnValue({ data: { data: [{ id: '1' }] } })
 		mocks.createQueryEnabledFn.mockImplementation(({ getEnabled }) => {
 			return () => getEnabled() !== false
 		})
 		mocks.createQueryFn.mockReturnValue(vi.fn())
-		mocks.createQueryKey.mockReturnValue(['posts'])
+		mocks.createQueryKey.mockReturnValue(['posts', 'getMany'])
 		mocks.createSubscribeCallback.mockReturnValue(vi.fn())
 		mocks.createSuccessHandler.mockReturnValue(vi.fn())
 		mocks.getSubscribeChannel.mockReturnValue('resources/posts')
-		mocks.getSubscribeParams.mockReturnValue({
-			resource: 'posts',
-			type: 'list',
-		})
-		mocks.resolveQueryProps.mockImplementation(({ resource }: { resource: string }) => ({
+		mocks.getSubscribeParams.mockReturnValue({ resource: 'posts', type: 'many' })
+		mocks.resolveQueryProps.mockImplementation(({ resource, ids }: { resource: string, ids: string[] }) => ({
 			resource,
+			ids,
 			fetcherName: 'default',
-			pagination: undefined,
-			sorters: undefined,
-			filters: undefined,
 			meta: undefined,
 		}))
-		mocks.useCheckError.mockReturnValue({
-			mutateAsync: vi.fn(),
-		})
+		mocks.useCheckError.mockReturnValue({ mutateAsync: vi.fn() })
 		mocks.useFetchersContext.mockReturnValue({})
 		mocks.useNotify.mockReturnValue({})
 		mocks.useQueryClientContext.mockReturnValue({})
-		mocks.useRealtimeOptions.mockReturnValue({
-			value: {
-				mode: 'auto',
-			},
-		})
+		mocks.useRealtimeOptions.mockReturnValue({ value: { mode: 'auto' } })
 		mocks.useTranslate.mockReturnValue(vi.fn())
-	})
-
-	it('should expose records accessor and subscribe params', () => {
-		const result = useGetList({
-			resource: 'posts',
-		} as any)
-
-		expect(result.records).toEqual([{ id: '1' }])
-		expect(mocks.useSubscribe).toHaveBeenCalledTimes(1)
-
-		const subscribeProps = mocks.useSubscribe.mock.calls[0][0]()
-		expect(subscribeProps).toMatchObject({
-			channel: 'resources/posts',
-			params: {
-				resource: 'posts',
-				type: 'list',
-			},
-			actions: ['any'],
-		})
-		expect(subscribeProps.enabled()).toBe(true)
 	})
 
 	it('should preserve the previous enabled snapshot when accessor props change', () => {
 		let isEnabled = $state(false)
 
-		useGetList(() => ({
+		useGetMany(() => ({
 			resource: 'posts',
+			ids: ['1'],
 			queryOptions: {
 				enabled: isEnabled,
 			},
-		}) as any)
+		}))
 
 		const getQueryOptions = mocks.createQuery.mock.calls[0][0]
 		const disabledOptions = getQueryOptions()

--- a/packages/svelte/src/query/get-many.svelte.ts
+++ b/packages/svelte/src/query/get-many.svelte.ts
@@ -72,13 +72,16 @@ export function useGetMany<
 		aggregate: extract(resolvedProps.aggregate),
 	}))
 	const queryKey = $derived.by(() => GetMany.createQueryKey({ props: queryProps }))
-	const queryEnabled = GetMany.createQueryEnabledFn({
-		getEnabled: () => resolvedProps.queryOptions?.enabled,
-		getQueryKey: () => queryKey,
-		getIds: () => queryProps.ids,
-		getResource: () => queryProps.resource,
-		getQueryOptions: () => resolvedProps.queryOptions,
-		queryClient,
+	const enabledFn = $derived.by(() => {
+		const queryOptions = resolvedProps.queryOptions
+		return GetMany.createQueryEnabledFn({
+			getEnabled: () => queryOptions?.enabled,
+			getQueryKey: () => queryKey,
+			getIds: () => queryProps.ids,
+			getResource: () => queryProps.resource,
+			getQueryOptions: () => queryOptions,
+			queryClient,
+		})
 	})
 	const queryFn = GetMany.createQueryFn<TData, TResultData, TError>({
 		fetchers,
@@ -109,7 +112,7 @@ export function useGetMany<
 			...resolvedProps.queryOptions,
 			queryKey,
 			queryFn,
-			enabled: queryEnabled,
+			enabled: enabledFn,
 			placeholderData,
 		}),
 		() => queryClient,
@@ -143,7 +146,7 @@ export function useGetMany<
 		callback,
 		meta: queryProps.meta,
 		actions: [RealtimeAction.Any],
-		enabled: queryEnabled,
+		enabled: enabledFn,
 	}), context)
 
 	return withAccessors(query, {

--- a/packages/svelte/src/query/get-one.svelte.test.ts
+++ b/packages/svelte/src/query/get-one.svelte.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { useGetList } from './get-list.svelte'
+import { useGetOne } from './get-one.svelte'
 
 const mocks = vi.hoisted(() => ({
 	createQuery: vi.fn(),
@@ -29,7 +29,7 @@ vi.mock('@ginjou/core', () => ({
 	RealtimeAction: {
 		Any: 'any',
 	},
-	GetList: {
+	GetOne: {
 		createErrorHandler: mocks.createErrorHandler,
 		createPlacholerDataFn: mocks.createPlacholerDataFn,
 		createQueryEnabledFn: mocks.createQueryEnabledFn,
@@ -74,7 +74,7 @@ vi.mock('./query-client', () => ({
 	useQueryClientContext: mocks.useQueryClientContext,
 }))
 
-describe('useGetList', () => {
+describe('useGetOne', () => {
 	beforeEach(() => {
 		mocks.createErrorHandler.mockReset()
 		mocks.createPlacholerDataFn.mockReset()
@@ -100,27 +100,26 @@ describe('useGetList', () => {
 		mocks.createPlacholerDataFn.mockReturnValue(undefined)
 		mocks.createQuery.mockReturnValue({
 			data: {
-				data: [{ id: '1' }],
+				data: { id: '1' },
 			},
 		})
 		mocks.createQueryEnabledFn.mockImplementation(({ getEnabled }) => {
 			return () => getEnabled() !== false
 		})
 		mocks.createQueryFn.mockReturnValue(vi.fn())
-		mocks.createQueryKey.mockReturnValue(['posts'])
+		mocks.createQueryKey.mockReturnValue(['posts', 'getOne', '1'])
 		mocks.createSubscribeCallback.mockReturnValue(vi.fn())
 		mocks.createSuccessHandler.mockReturnValue(vi.fn())
 		mocks.getSubscribeChannel.mockReturnValue('resources/posts')
 		mocks.getSubscribeParams.mockReturnValue({
 			resource: 'posts',
-			type: 'list',
+			id: '1',
+			type: 'one',
 		})
-		mocks.resolveQueryProps.mockImplementation(({ resource }: { resource: string }) => ({
+		mocks.resolveQueryProps.mockImplementation(({ resource, id }: { resource: string, id: string }) => ({
 			resource,
+			id,
 			fetcherName: 'default',
-			pagination: undefined,
-			sorters: undefined,
-			filters: undefined,
 			meta: undefined,
 		}))
 		mocks.useCheckError.mockReturnValue({
@@ -137,35 +136,16 @@ describe('useGetList', () => {
 		mocks.useTranslate.mockReturnValue(vi.fn())
 	})
 
-	it('should expose records accessor and subscribe params', () => {
-		const result = useGetList({
-			resource: 'posts',
-		} as any)
-
-		expect(result.records).toEqual([{ id: '1' }])
-		expect(mocks.useSubscribe).toHaveBeenCalledTimes(1)
-
-		const subscribeProps = mocks.useSubscribe.mock.calls[0][0]()
-		expect(subscribeProps).toMatchObject({
-			channel: 'resources/posts',
-			params: {
-				resource: 'posts',
-				type: 'list',
-			},
-			actions: ['any'],
-		})
-		expect(subscribeProps.enabled()).toBe(true)
-	})
-
 	it('should preserve the previous enabled snapshot when accessor props change', () => {
 		let isEnabled = $state(false)
 
-		useGetList(() => ({
+		useGetOne(() => ({
 			resource: 'posts',
+			id: '1',
 			queryOptions: {
 				enabled: isEnabled,
 			},
-		}) as any)
+		}))
 
 		const getQueryOptions = mocks.createQuery.mock.calls[0][0]
 		const disabledOptions = getQueryOptions()

--- a/packages/svelte/src/query/get-one.svelte.ts
+++ b/packages/svelte/src/query/get-one.svelte.ts
@@ -71,12 +71,15 @@ export function useGetOne<
 	const queryKey = $derived.by(() => GetOne.createQueryKey({
 		props: queryProps,
 	}))
-	const enabledFn = GetOne.createQueryEnabledFn({
-		getEnabled: () => resolvedProps.queryOptions?.enabled,
-		getQueryKey: () => queryKey,
-		getId: () => queryProps.id,
-		getQueryOptions: () => resolvedProps.queryOptions,
-		queryClient,
+	const enabledFn = $derived.by(() => {
+		const queryOptions = resolvedProps.queryOptions
+		return GetOne.createQueryEnabledFn({
+			getEnabled: () => queryOptions?.enabled,
+			getQueryKey: () => queryKey,
+			getId: () => queryProps.id,
+			getQueryOptions: () => queryOptions,
+			queryClient,
+		})
 	})
 	const queryFn = GetOne.createQueryFn<TData>({
 		fetchers,

--- a/packages/vue/src/auth/authenticated.test.ts
+++ b/packages/vue/src/auth/authenticated.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest'
+import { computed, nextTick, ref, unref } from 'vue-demi'
+import { queryClient } from '../../test/mock-fetcher'
+import { mountSetup } from '../../test/mount'
+import { useAuthenticated } from './authenticated'
+
+describe('useAuthenticated', () => {
+	it('should check auth when computed queryOptions.enabled becomes true', async () => {
+		const isEnabled = ref(false)
+		const check = vi.fn(() => Promise.resolve({ authenticated: true }))
+		const queryOptions = computed(() => ({
+			enabled: unref(isEnabled),
+		}))
+
+		const { result } = mountSetup(() => useAuthenticated(
+			{ queryOptions },
+			{
+				queryClient,
+				auth: {
+					login: vi.fn(),
+					logout: vi.fn(),
+					check,
+					checkError: vi.fn(),
+				},
+			},
+		))
+
+		expect(unref(result.isFetched)).toBeFalsy()
+		expect(check).not.toBeCalled()
+
+		isEnabled.value = true
+		await nextTick()
+
+		await vi.waitFor(() => {
+			expect(unref(result.isFetched)).toBeTruthy()
+		})
+		expect(check).toBeCalled()
+	})
+})

--- a/packages/vue/src/auth/authenticated.ts
+++ b/packages/vue/src/auth/authenticated.ts
@@ -48,20 +48,19 @@ export function useAuthenticated<
 		auth,
 		getParams,
 	})
-	const enabledFn = CheckAuth.createQueryEnabledFn({
-		getEnabled: () => unref(props?.queryOptions)?.enabled,
-		getAuth: () => auth,
+	const enabledFn = computed(() => {
+		const queryOptions = unref(props?.queryOptions)
+		return CheckAuth.createQueryEnabledFn({
+			getEnabled: () => queryOptions?.enabled,
+			getAuth: () => auth,
+		})
 	})
 	const query = useQuery<CheckAuthResult, TError>(
 		computed(() => ({
 			...unref(props?.queryOptions),
 			queryKey,
 			queryFn,
-			enabled: () => {
-				// eslint-disable-next-line ts/no-unused-expressions
-				unref(props?.queryOptions)?.enabled
-				return enabledFn
-			},
+			enabled: () => unref(enabledFn),
 			retry: false,
 		})),
 		queryClient,

--- a/packages/vue/src/auth/identity.test.ts
+++ b/packages/vue/src/auth/identity.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest'
+import { computed, nextTick, ref, unref } from 'vue-demi'
+import { queryClient } from '../../test/mock-fetcher'
+import { mountSetup } from '../../test/mount'
+import { useGetIdentity } from './identity'
+
+describe('useGetIdentity', () => {
+	it('should get identity when computed queryOptions.enabled becomes true', async () => {
+		const isEnabled = ref(false)
+		const getIdentity = vi.fn(() => Promise.resolve({ id: '1' }))
+		const queryOptions = computed(() => ({
+			enabled: unref(isEnabled),
+		}))
+
+		const { result } = mountSetup(() => useGetIdentity(
+			{ queryOptions },
+			{
+				queryClient,
+				auth: {
+					login: vi.fn(),
+					logout: vi.fn(),
+					check: vi.fn(),
+					checkError: vi.fn(),
+					getIdentity,
+				},
+			},
+		))
+
+		expect(unref(result.isFetched)).toBeFalsy()
+		expect(getIdentity).not.toBeCalled()
+
+		isEnabled.value = true
+		await nextTick()
+
+		await vi.waitFor(() => {
+			expect(unref(result.isFetched)).toBeTruthy()
+		})
+		expect(getIdentity).toBeCalled()
+	})
+})

--- a/packages/vue/src/auth/identity.ts
+++ b/packages/vue/src/auth/identity.ts
@@ -48,9 +48,12 @@ export function useGetIdentity<
 		auth,
 		getParams,
 	})
-	const enabledFn = Identity.createQueryEnabledFn({
-		getEnabled: () => unref(props?.queryOptions)?.enabled,
-		getAuth: () => auth,
+	const enabledFn = computed(() => {
+		const queryOptions = unref(props?.queryOptions)
+		return Identity.createQueryEnabledFn({
+			getEnabled: () => queryOptions?.enabled,
+			getAuth: () => auth,
+		})
 	})
 	const query = useQuery<GetIdentityResult<TData>, TError>(
 		computed(() => ({
@@ -58,11 +61,7 @@ export function useGetIdentity<
 			...unref(props?.queryOptions) as any,
 			queryKey,
 			queryFn,
-			enabled: () => {
-				// eslint-disable-next-line ts/no-unused-expressions
-				unref(props?.queryOptions)?.enabled
-				return enabledFn
-			},
+			enabled: () => unref(enabledFn),
 		})),
 		queryClient,
 	)

--- a/packages/vue/src/authz/can.test.ts
+++ b/packages/vue/src/authz/can.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest'
+import { computed, nextTick, ref, unref } from 'vue-demi'
+import { queryClient } from '../../test/mock-fetcher'
+import { mountSetup } from '../../test/mount'
+import { useCanAccess } from './can'
+
+describe('useCanAccess', () => {
+	it('should check access when computed queryOptions.enabled becomes true', async () => {
+		const isEnabled = ref(false)
+		const access = vi.fn(() => Promise.resolve({ can: true }))
+		const queryOptions = computed(() => ({
+			enabled: unref(isEnabled),
+		}))
+
+		const { result } = mountSetup(() => useCanAccess(
+			{
+				action: 'list',
+				resource: 'posts',
+				queryOptions,
+			},
+			{
+				queryClient,
+				authz: {
+					access,
+				},
+			},
+		))
+
+		expect(unref(result.isFetched)).toBeFalsy()
+		expect(access).not.toBeCalled()
+
+		isEnabled.value = true
+		await nextTick()
+
+		await vi.waitFor(() => {
+			expect(unref(result.isFetched)).toBeTruthy()
+		})
+		expect(access).toBeCalled()
+	})
+})

--- a/packages/vue/src/authz/can.ts
+++ b/packages/vue/src/authz/can.ts
@@ -53,20 +53,19 @@ export function useCanAccess<
 		authz,
 		getParams: () => unref(params),
 	})
-	const enabledFn = CanAccess.createQueryEnabledFn({
-		getAuthz: () => authz,
-		getEnabled: () => unref(props.queryOptions)?.enabled,
+	const enabledFn = computed(() => {
+		const queryOptions = unref(props.queryOptions)
+		return CanAccess.createQueryEnabledFn({
+			getAuthz: () => authz,
+			getEnabled: () => queryOptions?.enabled,
+		})
 	})
 	const query = useQuery<AccessCanResult, TError>(
 		computed(() => ({
 			...unref(props.queryOptions),
 			queryKey,
 			queryFn,
-			enabled: () => {
-				// eslint-disable-next-line ts/no-unused-expressions
-				unref(props?.queryOptions)?.enabled
-				return enabledFn
-			},
+			enabled: () => unref(enabledFn),
 			retry: false,
 		})),
 		queryClient,

--- a/packages/vue/src/authz/permissions.test.ts
+++ b/packages/vue/src/authz/permissions.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest'
+import { computed, nextTick, ref, unref } from 'vue-demi'
+import { queryClient } from '../../test/mock-fetcher'
+import { mountSetup } from '../../test/mount'
+import { usePermissions } from './permissions'
+
+describe('usePermissions', () => {
+	it('should get permissions when computed queryOptions.enabled becomes true', async () => {
+		const isEnabled = ref(false)
+		const getPermissions = vi.fn(() => Promise.resolve(['posts:list']))
+		const queryOptions = computed(() => ({
+			enabled: unref(isEnabled),
+		}))
+
+		const { result } = mountSetup(() => usePermissions(
+			{ queryOptions },
+			{
+				queryClient,
+				authz: {
+					getPermissions,
+				},
+			},
+		))
+
+		expect(unref(result.isFetched)).toBeFalsy()
+		expect(getPermissions).not.toBeCalled()
+
+		isEnabled.value = true
+		await nextTick()
+
+		await vi.waitFor(() => {
+			expect(unref(result.isFetched)).toBeTruthy()
+		})
+		expect(getPermissions).toBeCalled()
+	})
+})

--- a/packages/vue/src/authz/permissions.ts
+++ b/packages/vue/src/authz/permissions.ts
@@ -48,9 +48,12 @@ export function usePermissions<
 		authz,
 		getParams,
 	})
-	const enabledFn = Permissions.createQueryEnabledFn({
-		getAuthz: () => authz,
-		getEnabled: () => unref(props?.queryOptions)?.enabled,
+	const enabledFn = computed(() => {
+		const queryOptions = unref(props?.queryOptions)
+		return Permissions.createQueryEnabledFn({
+			getAuthz: () => authz,
+			getEnabled: () => queryOptions?.enabled,
+		})
 	})
 	const query = useQuery<GetPermissionsResult<TData>, TError>(
 		computed(() => ({
@@ -58,11 +61,7 @@ export function usePermissions<
 			...unref(props?.queryOptions) as any,
 			queryKey,
 			queryFn,
-			enabled: () => {
-				// eslint-disable-next-line ts/no-unused-expressions
-				unref(props?.queryOptions)?.enabled
-				return enabledFn
-			},
+			enabled: () => unref(enabledFn),
 		})),
 		queryClient,
 	)

--- a/packages/vue/src/query/custom.test.ts
+++ b/packages/vue/src/query/custom.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest'
+import { computed, nextTick, ref, unref } from 'vue-demi'
+import { MockFetchers, queryClient } from '../../test/mock-fetcher'
+import { mountTestApp } from '../../test/mount'
+import { useCustom } from './custom'
+
+describe('useCustom', () => {
+	it('should fetch when computed queryOptions.enabled becomes true', async () => {
+		const isEnabled = ref(false)
+		const queryOptions = computed(() => ({
+			enabled: unref(isEnabled),
+		}))
+
+		const { result } = mountTestApp(
+			() => useCustom({
+				url: '/posts/1',
+				method: 'get',
+				queryOptions,
+			}),
+			{
+				queryClient,
+				fetchers: MockFetchers,
+			},
+		)
+
+		expect(unref(result.isFetched)).toBeFalsy()
+
+		isEnabled.value = true
+		await nextTick()
+
+		await vi.waitFor(() => {
+			expect(unref(result.isFetched)).toBeTruthy()
+		})
+	})
+})

--- a/packages/vue/src/query/custom.ts
+++ b/packages/vue/src/query/custom.ts
@@ -99,25 +99,26 @@ export function useCustom<
 		getErrorNotify: () => unref(props.errorNotify),
 		emitParent: (...args) => unref(props.queryOptions)?.onError?.(...args),
 	})
-	const enabledFn = Custom.createQueryEnabledFn<TData, TError, TResultData>({
-		getQueryKey: () => unref(queryKey),
-		getEnabled: () => unref(props.queryOptions)?.enabled,
-		getQueryOptions: () => unref(props.queryOptions),
-		queryClient,
+	const enabledFn = computed(() => {
+		const queryOptions = unref(props.queryOptions)
+		return Custom.createQueryEnabledFn<TData, TError, TResultData>({
+			getQueryKey: () => unref(queryKey),
+			getEnabled: () => queryOptions?.enabled,
+			getQueryOptions: () => queryOptions,
+			queryClient,
+		})
 	})
 
 	const query = useQuery<CustomResult<TData>, TError, CustomResult<TResultData>>(
-		computed(() => ({
-			// FIXME: type
-			...unref(props.queryOptions) as any,
-			queryKey,
-			queryFn,
-			enabled: () => {
-				// eslint-disable-next-line ts/no-unused-expressions
-				unref(props?.queryOptions)?.enabled
-				return enabledFn
-			},
-		})),
+		computed(() => {
+			return {
+				// FIXME: type
+				...unref(props.queryOptions) as any,
+				queryKey,
+				queryFn,
+				enabled: () => unref(enabledFn),
+			}
+		}),
 		queryClient,
 	)
 

--- a/packages/vue/src/query/get-infinite-list.test.ts
+++ b/packages/vue/src/query/get-infinite-list.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
-import { unref } from 'vue-demi'
+import { computed, nextTick, ref, unref } from 'vue-demi'
 import { MockFetchers, queryClient } from '../../test/mock-fetcher'
+import { MockRealtimes, subscribeFn } from '../../test/mock-realtime'
 import { mountTestApp } from '../../test/mount'
 import { useGetInfiniteList } from './get-infinite-list'
 
@@ -28,6 +29,40 @@ describe('useGetList', () => {
 			expect(unref(result.data)?.pages[0]).not.toBeUndefined()
 			expect(unref(result.data)?.pageParams[0]).toBe(1)
 			expect(unref(result.data)?.pages[0].pagination!.current).toBe(1)
+		})
+
+		it('should fetch and subscribe when computed queryOptions.enabled becomes true', async () => {
+			const isEnabled = ref(false)
+			const queryOptions = computed(() => ({
+				enabled: unref(isEnabled),
+			}))
+
+			const { result } = mountTestApp(
+				() => useGetInfiniteList({
+					resource: 'posts',
+					pagination: {
+						current: 1,
+						perPage: 10,
+					},
+					queryOptions,
+				}),
+				{
+					queryClient,
+					fetchers: MockFetchers,
+					realtime: MockRealtimes,
+				},
+			)
+
+			expect(unref(result.isFetched)).toBeFalsy()
+			expect(subscribeFn).not.toBeCalled()
+
+			isEnabled.value = true
+			await nextTick()
+
+			await vi.waitFor(() => {
+				expect(unref(result.isFetched)).toBeTruthy()
+			})
+			expect(subscribeFn).toBeCalled()
 		})
 	})
 })

--- a/packages/vue/src/query/get-infinite-list.ts
+++ b/packages/vue/src/query/get-infinite-list.ts
@@ -83,13 +83,6 @@ export function useGetInfiniteList<
 	const initialPageParam = computed(() => GetInfiniteList.getInitialPageParam({
 		props: unref(queryProps),
 	}))
-	const enabledFn = GetInfiniteList.createQueryEnabledFn({
-		getEnabled: () => unref(props.queryOptions)?.enabled,
-		getQueryKey: () => unref(queryKey),
-		getResource: () => unref(queryProps).resource,
-		getQueryOptions: () => unref(props.queryOptions),
-		queryClient,
-	})
 	const queryFn = GetInfiniteList.createQueryFn<TData, TPageParam>({
 		getProps,
 		queryClient,
@@ -112,23 +105,31 @@ export function useGetInfiniteList<
 	const placeholderData = GetInfiniteList.createPlacholerDataFn<TData, TError, TPageParam>()
 	const getNextPageParam = GetInfiniteList.createGetNextPageParamFn<TData, TPageParam>()
 	const getPreviousPageParam = GetInfiniteList.createGetPreviousPageParamFn<TData, TPageParam>()
+	const enabledFn = computed(() => {
+		const queryOptions = unref(props.queryOptions)
+		return GetInfiniteList.createQueryEnabledFn({
+			getEnabled: () => queryOptions?.enabled,
+			getQueryKey: () => unref(queryKey),
+			getResource: () => unref(queryProps).resource,
+			getQueryOptions: () => queryOptions,
+			queryClient,
+		})
+	})
 
 	const query = useInfiniteQuery<GetInfiniteListResult<TData, TPageParam>, TError, InfiniteData<GetInfiniteListResult<TResultData, TPageParam>, TPageParam>, any, TPageParam>(
-		computed(() => ({
-			initialPageParam,
-			getNextPageParam,
-			getPreviousPageParam,
-			// FIXME: type
-			...unref(props.queryOptions) as any,
-			queryKey,
-			queryFn,
-			enabled: () => {
-				// eslint-disable-next-line ts/no-unused-expressions
-				unref(props?.queryOptions)?.enabled
-				return enabledFn
-			},
-			placeholderData,
-		})),
+		computed(() => {
+			return {
+				initialPageParam,
+				getNextPageParam,
+				getPreviousPageParam,
+				// FIXME: type
+				...unref(props.queryOptions) as any,
+				queryKey,
+				queryFn,
+				enabled: () => unref(enabledFn),
+				placeholderData,
+			}
+		}),
 		queryClient,
 	)
 
@@ -160,11 +161,7 @@ export function useGetInfiniteList<
 			getFetcherName: () => unref(queryProps).fetcherName,
 		}),
 		actions: [RealtimeAction.Any],
-		enabled: toRef(() => {
-			// eslint-disable-next-line ts/no-unused-expressions
-			unref(props?.queryOptions)?.enabled
-			return enabledFn
-		}),
+		enabled: enabledFn,
 	}, context)
 
 	return {

--- a/packages/vue/src/query/get-list.test.ts
+++ b/packages/vue/src/query/get-list.test.ts
@@ -1,6 +1,6 @@
 import { RealtimeAction } from '@ginjou/core'
 import { describe, expect, it, vi } from 'vitest'
-import { unref } from 'vue-demi'
+import { computed, nextTick, ref, unref } from 'vue-demi'
 import { MockFetchers, queryClient } from '../../test/mock-fetcher'
 import { expectUnsubscribeCalled, MockRealtimes, subscribeFn } from '../../test/mock-realtime'
 import { mountTestApp } from '../../test/mount'
@@ -79,6 +79,36 @@ describe('useGetList', () => {
 
 			expect(unref(result.isFetched)).toBeFalsy()
 			expect(subscribeFn).not.toBeCalled()
+		})
+
+		it('should fetch and subscribe when computed queryOptions.enabled becomes true', async () => {
+			const isEnabled = ref(false)
+			const queryOptions = computed(() => ({
+				enabled: unref(isEnabled),
+			}))
+
+			const { result } = mountTestApp(
+				() => useGetList({
+					resource: 'posts',
+					queryOptions,
+				}),
+				{
+					queryClient,
+					fetchers: MockFetchers,
+					realtime: MockRealtimes,
+				},
+			)
+
+			expect(unref(result.isFetched)).toBeFalsy()
+			expect(subscribeFn).not.toBeCalled()
+
+			isEnabled.value = true
+			await nextTick()
+
+			await vi.waitFor(() => {
+				expect(unref(result.isFetched)).toBeTruthy()
+			})
+			expect(subscribeFn).toBeCalled()
 		})
 	})
 })

--- a/packages/vue/src/query/get-list.ts
+++ b/packages/vue/src/query/get-list.ts
@@ -77,13 +77,6 @@ export function useGetList<
 	const queryKey = computed(() => GetList.createQueryKey<TPageParam>({
 		props: unref(queryProps),
 	}))
-	const enabledFn = GetList.createQueryEnabledFn({
-		getEnabled: () => unref(props.queryOptions)?.enabled,
-		getQueryKey: () => unref(queryKey),
-		getResource: () => unref(queryProps).resource,
-		getQueryOptions: () => unref(props.queryOptions),
-		queryClient,
-	})
 	const queryFn = GetList.createQueryFn<TData, TResultData, TError, TPageParam>({
 		getProps,
 		queryClient,
@@ -104,20 +97,28 @@ export function useGetList<
 		emitParent: (...args) => unref(props.queryOptions)?.onError?.(...args),
 	})
 	const placeholderData = GetList.createPlacholerDataFn<TData, TError, TPageParam>()
+	const enabledFn = computed(() => {
+		const queryOptions = unref(props.queryOptions)
+		return GetList.createQueryEnabledFn({
+			getEnabled: () => queryOptions?.enabled,
+			getQueryKey: () => unref(queryKey),
+			getResource: () => unref(queryProps).resource,
+			getQueryOptions: () => queryOptions,
+			queryClient,
+		})
+	})
 
 	const query = useQuery<GetListResult<TData, TPageParam>, TError, GetListResult<TResultData, TPageParam>>(
-		computed(() => ({
-			// FIXME: type
-			...unref(props.queryOptions) as any,
-			queryKey,
-			queryFn,
-			enabled: () => {
-				// eslint-disable-next-line ts/no-unused-expressions
-				unref(props?.queryOptions)?.enabled
-				return enabledFn
-			},
-			placeholderData,
-		})),
+		computed(() => {
+			return {
+				// FIXME: type
+				...unref(props.queryOptions) as any,
+				queryKey,
+				queryFn,
+				enabled: () => unref(enabledFn),
+				placeholderData,
+			}
+		}),
 		queryClient,
 	)
 
@@ -145,11 +146,7 @@ export function useGetList<
 			getFetcherName: () => unref(queryProps).fetcherName,
 		}),
 		actions: [RealtimeAction.Any],
-		enabled: toRef(() => {
-			// eslint-disable-next-line ts/no-unused-expressions
-			unref(props?.queryOptions)?.enabled
-			return enabledFn
-		}),
+		enabled: enabledFn,
 	}, context)
 
 	return {

--- a/packages/vue/src/query/get-many.test.ts
+++ b/packages/vue/src/query/get-many.test.ts
@@ -1,6 +1,6 @@
 import { RealtimeAction, SubscribeType } from '@ginjou/core'
 import { describe, expect, it, vi } from 'vitest'
-import { unref } from 'vue-demi'
+import { computed, nextTick, ref, unref } from 'vue-demi'
 import { MockFetchers, queryClient } from '../../test/mock-fetcher'
 import { expectUnsubscribeCalled, MockRealtimes, subscribeFn } from '../../test/mock-realtime'
 import { mountTestApp } from '../../test/mount'
@@ -80,6 +80,37 @@ describe('useGetMany', () => {
 
 			expect(unref(result.isFetched)).toBeFalsy()
 			expect(subscribeFn).not.toBeCalled()
+		})
+
+		it('should fetch and subscribe when computed queryOptions.enabled becomes true', async () => {
+			const isEnabled = ref(false)
+			const queryOptions = computed(() => ({
+				enabled: unref(isEnabled),
+			}))
+
+			const { result } = mountTestApp(
+				() => useGetMany({
+					resource: 'posts',
+					ids: ['1', '2'],
+					queryOptions,
+				}),
+				{
+					queryClient,
+					fetchers: MockFetchers,
+					realtime: MockRealtimes,
+				},
+			)
+
+			expect(unref(result.isFetched)).toBeFalsy()
+			expect(subscribeFn).not.toBeCalled()
+
+			isEnabled.value = true
+			await nextTick()
+
+			await vi.waitFor(() => {
+				expect(unref(result.isFetched)).toBeTruthy()
+			})
+			expect(subscribeFn).toBeCalled()
 		})
 	})
 })

--- a/packages/vue/src/query/get-many.ts
+++ b/packages/vue/src/query/get-many.ts
@@ -74,14 +74,6 @@ export function useGetMany<
 	const queryKey = computed(() => GetMany.createQueryKey({
 		props: unref(queryProps),
 	}))
-	const enabledFn = GetMany.createQueryEnabledFn({
-		getEnabled: () => unref(props.queryOptions)?.enabled,
-		getQueryKey: () => unref(queryKey),
-		getIds: () => unref(queryProps).ids,
-		getResource: () => unref(queryProps).resource,
-		getQueryOptions: () => unref(props.queryOptions),
-		queryClient,
-	})
 	const queryFn = GetMany.createQueryFn<TData, TResultData, TError>({
 		fetchers,
 		queryClient,
@@ -105,20 +97,29 @@ export function useGetMany<
 		getProps,
 		queryClient,
 	})
+	const enabledFn = computed(() => {
+		const queryOptions = unref(props.queryOptions)
+		return GetMany.createQueryEnabledFn({
+			getEnabled: () => queryOptions?.enabled,
+			getQueryKey: () => unref(queryKey),
+			getIds: () => unref(queryProps).ids,
+			getResource: () => unref(queryProps).resource,
+			getQueryOptions: () => queryOptions,
+			queryClient,
+		})
+	})
 
 	const query = useQuery<GetManyResult<TData>, TError, GetManyResult<TResultData>>(
-		computed(() => ({
-			// FIXME: type
-			...unref(props.queryOptions) as any,
-			queryKey,
-			queryFn,
-			enabled: () => {
-				// eslint-disable-next-line ts/no-unused-expressions
-				unref(props?.queryOptions)?.enabled
-				return enabledFn
-			},
-			placeholderData,
-		})),
+		computed(() => {
+			return {
+				// FIXME: type
+				...unref(props.queryOptions) as any,
+				queryKey,
+				queryFn,
+				enabled: () => unref(enabledFn),
+				placeholderData,
+			}
+		}),
 		queryClient,
 	)
 	useQueryCallbacks<GetManyResult<TResultData>, TError>({
@@ -145,11 +146,7 @@ export function useGetMany<
 			getFetcherName: () => unref(queryProps).fetcherName,
 		}),
 		actions: [RealtimeAction.Any],
-		enabled: toRef(() => {
-			// eslint-disable-next-line ts/no-unused-expressions
-			unref(props?.queryOptions)?.enabled
-			return enabledFn
-		}),
+		enabled: enabledFn,
 	}, context)
 
 	return {

--- a/packages/vue/src/query/get-one.test.ts
+++ b/packages/vue/src/query/get-one.test.ts
@@ -1,6 +1,6 @@
 import { RealtimeAction } from '@ginjou/core'
 import { describe, expect, it, vi } from 'vitest'
-import { unref } from 'vue-demi'
+import { computed, nextTick, ref, unref } from 'vue-demi'
 import { MockFetchers, queryClient } from '../../test/mock-fetcher'
 import { expectUnsubscribeCalled, MockRealtimes, subscribeFn } from '../../test/mock-realtime'
 import { mountTestApp } from '../../test/mount'
@@ -25,8 +25,8 @@ describe('useGetOne', () => {
 				expect(unref(result.isFetched)).toBeTruthy()
 			})
 
-			expect(subscribeFn).toBeCalled()
-			expect(subscribeFn).toBeCalledWith({
+			expect(subscribeFn).toHaveBeenCalled()
+			expect(subscribeFn).toHaveBeenCalledWith({
 				channel: 'resources/posts',
 				actions: [RealtimeAction.Any],
 				callback: expect.any(Function),
@@ -79,7 +79,38 @@ describe('useGetOne', () => {
 			)
 
 			expect(unref(result.isFetched)).toBeFalsy()
-			expect(subscribeFn).not.toBeCalled()
+			expect(subscribeFn).not.toHaveBeenCalled()
+		})
+
+		it('should fetch and subscribe when computed queryOptions.enabled becomes true', async () => {
+			const isEnabled = ref(false)
+			const queryOptions = computed(() => ({
+				enabled: unref(isEnabled),
+			}))
+
+			const { result } = mountTestApp(
+				() => useGetOne({
+					resource: 'posts',
+					id: '1',
+					queryOptions,
+				}),
+				{
+					queryClient,
+					fetchers: MockFetchers,
+					realtime: MockRealtimes,
+				},
+			)
+
+			expect(unref(result.isFetched)).toBeFalsy()
+			expect(subscribeFn).not.toHaveBeenCalled()
+
+			isEnabled.value = true
+			await nextTick()
+
+			await vi.waitFor(() => {
+				expect(unref(result.isFetched)).toBeTruthy()
+			})
+			expect(subscribeFn).toHaveBeenCalled()
 		})
 	})
 })

--- a/packages/vue/src/query/get-one.ts
+++ b/packages/vue/src/query/get-one.ts
@@ -72,13 +72,6 @@ export function useGetOne<
 	const queryKey = computed(() => GetOne.createQueryKey({
 		props: unref(queryProps),
 	}))
-	const enabledFn = GetOne.createQueryEnabledFn({
-		getEnabled: () => unref(props.queryOptions)?.enabled,
-		getQueryKey: () => unref(queryKey),
-		getId: () => unref(queryProps).id,
-		getQueryOptions: () => unref(props.queryOptions),
-		queryClient,
-	})
 	const queryFn = GetOne.createQueryFn<TData>({
 		fetchers,
 		getProps,
@@ -98,20 +91,28 @@ export function useGetOne<
 		emitParent: (...args) => unref(props.queryOptions)?.onError?.(...args),
 	})
 	const placeholderData = GetOne.createPlacholerDataFn<TData, TError>()
+	const enabledFn = computed(() => {
+		const queryOptions = unref(props.queryOptions)
+		return GetOne.createQueryEnabledFn({
+			getEnabled: () => queryOptions?.enabled,
+			getQueryKey: () => unref(queryKey),
+			getId: () => unref(queryProps).id,
+			getQueryOptions: () => queryOptions,
+			queryClient,
+		})
+	})
 
 	const query = useQuery<GetOneResult<TData>, TError, GetOneResult<TResultData>>(
-		computed(() => ({
-			// FIXME: type
-			...unref(props.queryOptions) as any,
-			queryKey,
-			queryFn,
-			enabled: () => {
-				// eslint-disable-next-line ts/no-unused-expressions
-				unref(props?.queryOptions)?.enabled
-				return enabledFn
-			},
-			placeholderData,
-		})),
+		computed(() => {
+			return {
+				// FIXME: type
+				...unref(props.queryOptions) as any,
+				queryKey,
+				queryFn,
+				enabled: () => unref(enabledFn),
+				placeholderData,
+			}
+		}),
 		queryClient,
 	)
 
@@ -139,11 +140,7 @@ export function useGetOne<
 			getFetcherName: () => unref(queryProps).fetcherName,
 		}),
 		actions: [RealtimeAction.Any],
-		enabled: toRef(() => {
-			// eslint-disable-next-line ts/no-unused-expressions
-			unref(props?.queryOptions)?.enabled
-			return enabledFn
-		}),
+		enabled: enabledFn,
 	}, context)
 
 	return {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive unit tests for authentication, authorization, and data query hooks across Svelte and Vue packages to ensure correct enable/disable behavior.

* **Refactor**
  * Improved internal query state reactivity to ensure enable/disable flags respond correctly when reactive dependencies change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->