### PR TITLE
feat: use GetManyByOne for selected values

### DIFF
--- a/packages/core/src/controller/select.ts
+++ b/packages/core/src/controller/select.ts
@@ -1,5 +1,5 @@
 import type { Simplify } from 'type-fest'
-import type { BaseRecord, Filters, GetList, GetListResult, GetMany, GetManyResult, Pagination } from '../query'
+import type { BaseRecord, Filters, GetList, GetListResult, GetManyByOne, GetManyResult, Pagination } from '../query'
 import { unionBy } from 'es-toolkit'
 import { get } from 'es-toolkit/compat'
 import { FilterOperator } from '../query'
@@ -22,7 +22,8 @@ export type Props<
 		value?: any | any[] // TODO: generice
 		searchToFilters?: SearchToFiltersFn<any> // TODO: generic
 		queryOptionsForOptions?: NonNullable<GetList.Props<TData, TError, TResultData, TPageParam>['queryOptions']>
-		queryOptionsForValue?: NonNullable<GetMany.Props<TData, TError, TResultData>['queryOptions']>
+		queryOptionsForValue?: NonNullable<GetManyByOne.Props<TData, TError, TResultData>['queryOptions']>
+		metaForValue?: NonNullable<GetManyByOne.Props<TData, TError, TResultData>['meta']>
 	}
 >
 

--- a/packages/svelte/src/controller/select.svelte.test.ts
+++ b/packages/svelte/src/controller/select.svelte.test.ts
@@ -1,0 +1,232 @@
+import { FilterOperator } from '@ginjou/core'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useSelect } from './select.svelte'
+
+const mocks = vi.hoisted(() => ({
+	useGetList: vi.fn(),
+	useGetManyByOne: vi.fn(),
+	useResource: vi.fn(),
+}))
+
+vi.mock('../query', () => ({
+	useGetList: mocks.useGetList,
+	useGetManyByOne: mocks.useGetManyByOne,
+}))
+
+vi.mock('./resource.svelte', () => ({
+	useResource: mocks.useResource,
+}))
+
+vi.mock('../utils/watch.svelte', () => ({
+	watch<T>(
+		source: () => T,
+		callback: (value: T, oldValue: T | undefined) => void,
+		options?: { immediate?: boolean },
+	) {
+		if (options?.immediate)
+			callback(source(), undefined)
+
+		return () => {}
+	},
+}))
+
+describe('useSelect', () => {
+	beforeEach(() => {
+		mocks.useGetList.mockReset()
+		mocks.useGetManyByOne.mockReset()
+		mocks.useResource.mockReset()
+
+		mocks.useResource.mockReturnValue({
+			value: {
+				resource: {
+					name: 'posts',
+				},
+			},
+		})
+	})
+
+	it('should hydrate multiple selected values and merge them with list options', () => {
+		let manyProps: (() => Record<string, unknown>) | undefined
+		const value = ['1', '2']
+
+		mocks.useGetList.mockReturnValue({
+			data: {
+				data: [
+					{ id: '1', title: 'Post 1' },
+				],
+			},
+		})
+		mocks.useGetManyByOne.mockImplementation((props) => {
+			manyProps = props
+			return {
+				data: {
+					data: [
+						{ id: '2', title: 'Post 2' },
+					],
+				},
+			}
+		})
+
+		const result = useSelect({
+			resource: 'posts',
+			value,
+		})
+
+		expect(manyProps?.().ids).toEqual(['1', '2'])
+		expect(result.options).toEqual([
+			{
+				label: 'Post 1',
+				value: '1',
+				data: { id: '1', title: 'Post 1' },
+			},
+			{
+				label: 'Post 2',
+				value: '2',
+				data: { id: '2', title: 'Post 2' },
+			},
+		])
+	})
+
+	it('should expose writable search and pagination state to the list query', () => {
+		let listProps: (() => Record<string, unknown>) | undefined
+
+		mocks.useGetList.mockImplementation((props) => {
+			listProps = props
+			return {}
+		})
+		mocks.useGetManyByOne.mockReturnValue({})
+
+		const result = useSelect({
+			resource: 'posts',
+			pagination: {
+				current: 1,
+				perPage: 10,
+			},
+		})
+
+		result.search = 'draft'
+		result.currentPage = 2
+		result.perPage = 25
+
+		expect(listProps?.().filters).toEqual([
+			{
+				field: 'title',
+				operator: FilterOperator.contains,
+				value: 'draft',
+			},
+		])
+		expect(listProps?.().pagination).toEqual({
+			current: 2,
+			perPage: 25,
+		})
+	})
+
+	it('should use custom label and value keys for options and search filters', () => {
+		let listProps: (() => Record<string, unknown>) | undefined
+
+		mocks.useGetList.mockImplementation((props) => {
+			listProps = props
+			return {
+				data: {
+					data: [
+						{
+							id: '1',
+							meta: { slug: 'post-1' },
+							author: { name: 'Jane' },
+						},
+					],
+				},
+			}
+		})
+		mocks.useGetManyByOne.mockReturnValue({})
+
+		const result = useSelect({
+			resource: 'posts',
+			labelKey: 'author.name',
+			valueKey: 'meta.slug',
+		})
+
+		result.search = 'Jane'
+
+		expect(result.options).toEqual([
+			{
+				label: 'Jane',
+				value: 'post-1',
+				data: {
+					id: '1',
+					meta: { slug: 'post-1' },
+					author: { name: 'Jane' },
+				},
+			},
+		])
+		expect(listProps?.().filters).toEqual([
+			{
+				field: 'author.name',
+				operator: FilterOperator.contains,
+				value: 'Jane',
+			},
+		])
+	})
+
+	it('should forward option and selected-value query configuration', () => {
+		let listProps: (() => Record<string, unknown>) | undefined
+		let manyProps: (() => Record<string, unknown>) | undefined
+		const queryOptionsForOptions = { staleTime: 1_000 }
+		const queryOptionsForValue = { enabled: false }
+		const metaForValue = { source: 'select' }
+
+		mocks.useGetList.mockImplementation((props) => {
+			listProps = props
+			return {}
+		})
+		mocks.useGetManyByOne.mockImplementation((props) => {
+			manyProps = props
+			return {}
+		})
+
+		useSelect({
+			resource: 'posts',
+			queryOptionsForOptions,
+			queryOptionsForValue,
+			metaForValue,
+		})
+
+		expect(listProps?.().queryOptions).toBe(queryOptionsForOptions)
+		expect(manyProps?.().queryOptions).toBe(queryOptionsForValue)
+		expect(manyProps?.().meta).toBe(metaForValue)
+	})
+
+	it('should use custom searchToFilters for the list query', () => {
+		let listProps: (() => Record<string, unknown>) | undefined
+		const searchToFilters = vi.fn(value => [
+			{
+				field: 'slug',
+				operator: FilterOperator.eq,
+				value,
+			},
+		])
+
+		mocks.useGetList.mockImplementation((props) => {
+			listProps = props
+			return {}
+		})
+		mocks.useGetManyByOne.mockReturnValue({})
+
+		const result = useSelect({
+			resource: 'posts',
+			searchToFilters,
+		})
+
+		result.search = 'draft-post'
+		const filters = listProps?.().filters
+
+		expect(searchToFilters).toHaveBeenLastCalledWith('draft-post')
+		expect(filters).toEqual([
+			{
+				field: 'slug',
+				operator: FilterOperator.eq,
+				value: 'draft-post',
+			},
+		])
+	})
+})

--- a/packages/svelte/src/controller/select.svelte.ts
+++ b/packages/svelte/src/controller/select.svelte.ts
@@ -1,10 +1,10 @@
 import type { BaseRecord } from '@ginjou/core'
 import type { Simplify } from 'type-fest'
-import type { UseGetListContext, UseGetListResult, UseGetManyContext } from '../query'
+import type { UseGetListContext, UseGetListResult, UseGetManyByOneContext } from '../query'
 import type { MaybeAccessor } from '../utils'
 import type { UseResourceContext } from './resource.svelte'
 import { Resource, Select } from '@ginjou/core'
-import { useGetList, useGetMany } from '../query'
+import { useGetList, useGetManyByOne } from '../query'
 import { extract, pickState, unbox, withAccessors } from '../utils'
 import { useResource } from './resource.svelte'
 
@@ -20,7 +20,7 @@ export type UseSelectProps<
 
 export type UseSelectContext = Simplify<
 	& UseGetListContext
-	& UseGetManyContext
+	& UseGetManyByOneContext
 	& UseResourceContext
 >
 
@@ -91,12 +91,12 @@ export function useSelect<
 		queryOptions: resolvedProps?.queryOptionsForOptions,
 	}), context)
 
-	const manyResult = useGetMany<TData, TError, TResultData>(() => ({
+	const manyResult = useGetManyByOne<TData, TError, TResultData>(() => ({
 		resource: resourceName,
 		ids,
 		fetcherName,
 		queryOptions: resolvedProps?.queryOptionsForValue,
-		meta: resolvedProps?.meta,
+		meta: resolvedProps?.metaForValue,
 	}), context)
 
 	const options = $derived.by(() => Select.getOptions({

--- a/packages/vue/src/controller/select.test.ts
+++ b/packages/vue/src/controller/select.test.ts
@@ -1,0 +1,236 @@
+import { FilterOperator } from '@ginjou/core'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref, unref } from 'vue-demi'
+import { useSelect } from './select'
+
+const mocks = vi.hoisted(() => ({
+	useGetList: vi.fn(),
+	useGetManyByOne: vi.fn(),
+	useResource: vi.fn(),
+}))
+
+vi.mock('../query', () => ({
+	useGetList: mocks.useGetList,
+	useGetManyByOne: mocks.useGetManyByOne,
+}))
+
+vi.mock('./resource', () => ({
+	useResource: mocks.useResource,
+}))
+
+describe('useSelect', () => {
+	beforeEach(() => {
+		mocks.useGetList.mockReset()
+		mocks.useGetManyByOne.mockReset()
+		mocks.useResource.mockReset()
+
+		mocks.useResource.mockReturnValue(ref({
+			resource: {
+				name: 'posts',
+			},
+		}))
+	})
+
+	it('should hydrate multiple selected values and merge them with list options', () => {
+		let manyProps: Record<string, unknown> | undefined
+		const value = ref(['1', '2'])
+
+		mocks.useGetList.mockReturnValue({
+			data: ref({
+				data: [
+					{ id: '1', title: 'Post 1' },
+				],
+			}),
+		})
+		mocks.useGetManyByOne.mockImplementation((props) => {
+			manyProps = props
+			return {
+				data: ref({
+					data: [
+						{ id: '2', title: 'Post 2' },
+					],
+				}),
+			}
+		})
+
+		const result = useSelect({
+			resource: 'posts',
+			value,
+		})
+
+		expect(unref(manyProps?.ids)).toEqual(['1', '2'])
+		expect(unref(result.options)).toEqual([
+			{
+				label: 'Post 1',
+				value: '1',
+				data: { id: '1', title: 'Post 1' },
+			},
+			{
+				label: 'Post 2',
+				value: '2',
+				data: { id: '2', title: 'Post 2' },
+			},
+		])
+
+		value.value = ['2']
+
+		expect(unref(manyProps?.ids)).toEqual(['2'])
+	})
+
+	it('should expose writable search and pagination refs to the list query', () => {
+		let listProps: Record<string, unknown> | undefined
+
+		mocks.useGetList.mockImplementation((props) => {
+			listProps = props
+			return {
+				data: ref(),
+			}
+		})
+		mocks.useGetManyByOne.mockReturnValue({
+			data: ref(),
+		})
+
+		const result = useSelect({
+			resource: 'posts',
+			pagination: {
+				current: 1,
+				perPage: 10,
+			},
+		})
+
+		result.search.value = 'draft'
+		result.currentPage.value = 2
+		result.perPage.value = 25
+
+		expect(unref(listProps?.filters)).toEqual([
+			{
+				field: 'title',
+				operator: FilterOperator.contains,
+				value: 'draft',
+			},
+		])
+		expect(unref(listProps?.pagination)).toEqual({
+			current: 2,
+			perPage: 25,
+		})
+	})
+
+	it('should use custom label and value keys for options and search filters', () => {
+		let listProps: Record<string, unknown> | undefined
+
+		mocks.useGetList.mockImplementation((props) => {
+			listProps = props
+			return {
+				data: ref({
+					data: [
+						{
+							id: '1',
+							meta: { slug: 'post-1' },
+							author: { name: 'Jane' },
+						},
+					],
+				}),
+			}
+		})
+		mocks.useGetManyByOne.mockReturnValue({
+			data: ref(),
+		})
+
+		const result = useSelect({
+			resource: 'posts',
+			labelKey: 'author.name',
+			valueKey: 'meta.slug',
+		})
+
+		result.search.value = 'Jane'
+
+		expect(unref(result.options)).toEqual([
+			{
+				label: 'Jane',
+				value: 'post-1',
+				data: {
+					id: '1',
+					meta: { slug: 'post-1' },
+					author: { name: 'Jane' },
+				},
+			},
+		])
+		expect(unref(listProps?.filters)).toEqual([
+			{
+				field: 'author.name',
+				operator: FilterOperator.contains,
+				value: 'Jane',
+			},
+		])
+	})
+
+	it('should forward option and selected-value query configuration', () => {
+		let listProps: Record<string, unknown> | undefined
+		let manyProps: Record<string, unknown> | undefined
+		const queryOptionsForOptions = { staleTime: 1_000 }
+		const queryOptionsForValue = { enabled: false }
+		const metaForValue = { source: 'select' }
+
+		mocks.useGetList.mockImplementation((props) => {
+			listProps = props
+			return {
+				data: ref(),
+			}
+		})
+		mocks.useGetManyByOne.mockImplementation((props) => {
+			manyProps = props
+			return {
+				data: ref(),
+			}
+		})
+
+		useSelect({
+			resource: 'posts',
+			queryOptionsForOptions,
+			queryOptionsForValue,
+			metaForValue,
+		})
+
+		expect(listProps?.queryOptions).toBe(queryOptionsForOptions)
+		expect(manyProps?.queryOptions).toBe(queryOptionsForValue)
+		expect(manyProps?.meta).toBe(metaForValue)
+	})
+
+	it('should use custom searchToFilters for the list query', () => {
+		let listProps: Record<string, unknown> | undefined
+		const searchToFilters = vi.fn(value => [
+			{
+				field: 'slug',
+				operator: FilterOperator.eq,
+				value,
+			},
+		])
+
+		mocks.useGetList.mockImplementation((props) => {
+			listProps = props
+			return {
+				data: ref(),
+			}
+		})
+		mocks.useGetManyByOne.mockReturnValue({
+			data: ref(),
+		})
+
+		const result = useSelect({
+			resource: 'posts',
+			searchToFilters,
+		})
+
+		result.search.value = 'draft-post'
+		const filters = unref(listProps?.filters)
+
+		expect(searchToFilters).toHaveBeenLastCalledWith('draft-post')
+		expect(filters).toEqual([
+			{
+				field: 'slug',
+				operator: FilterOperator.eq,
+				value: 'draft-post',
+			},
+		])
+	})
+})

--- a/packages/vue/src/controller/select.ts
+++ b/packages/vue/src/controller/select.ts
@@ -1,12 +1,12 @@
 import type { BaseRecord, Pagination } from '@ginjou/core'
 import type { Simplify } from 'type-fest'
 import type { ComputedRef, Ref } from 'vue-demi'
-import type { UseGetListContext, UseGetListResult, UseGetManyContext } from '../query'
+import type { UseGetListContext, UseGetListResult, UseGetManyByOneContext } from '../query'
 import type { ToMaybeRefs } from '../utils/refs'
 import type { UseResourceContext } from './resource'
 import { Resource, Select } from '@ginjou/core'
 import { computed, ref, unref } from 'vue-demi'
-import { useGetList, useGetMany } from '../query'
+import { useGetList, useGetManyByOne } from '../query'
 import { pickRef } from '../utils/pick-ref'
 import { useResource } from './resource'
 
@@ -21,7 +21,7 @@ export type UseSelectProps<
 
 export type UseSelectContext = Simplify<
 	& UseGetListContext
-	& UseGetManyContext
+	& UseGetManyByOneContext
 	& UseResourceContext
 >
 
@@ -88,15 +88,15 @@ export function useSelect<
 		filters,
 		pagination,
 		queryOptions: props?.queryOptionsForOptions,
-	})
+	}, context)
 
-	const manyResult = useGetMany<TData, TError, TResultData>({
+	const manyResult = useGetManyByOne<TData, TError, TResultData>({
 		resource: resourceName,
 		ids,
 		fetcherName,
 		queryOptions: props?.queryOptionsForValue,
-		meta: props?.meta,
-	})
+		meta: props?.metaForValue,
+	}, context)
 
 	const options = computed(() => Select.getOptions({
 		listData: unref(listResult.data),

--- a/packages/vue/src/controller/show.ts
+++ b/packages/vue/src/controller/show.ts
@@ -63,7 +63,7 @@ export function useShow<
 		resource: resourceName,
 		id,
 		fetcherName,
-	})
+	}, context)
 
 	watch(defaultId, (val) => {
 		id.value = val

--- a/stories/svelte/src/Select.stories.ts
+++ b/stories/svelte/src/Select.stories.ts
@@ -1,15 +1,29 @@
 import type { Meta, StoryObj } from '@storybook/svelte-vite'
 import { createPostHandlers } from '@ginjou/storybook-shared/mock-data'
 import SelectBasic from './SelectBasic.svelte'
+import SelectMultiple from './SelectMultiple.svelte'
 
 const meta = {
+	component: SelectBasic,
 	title: 'Controllers/Select',
-} satisfies Meta
+} satisfies Meta<typeof SelectBasic>
 
 export const Basic = {
 	name: 'Basic',
 	render: () => ({
 		Component: SelectBasic as any,
+	}),
+	parameters: {
+		msw: {
+			handlers: createPostHandlers(),
+		},
+	},
+} satisfies StoryObj<typeof meta>
+
+export const Multiple = {
+	name: 'Multiple',
+	render: () => ({
+		Component: SelectMultiple as any,
 	}),
 	parameters: {
 		msw: {

--- a/stories/svelte/src/SelectMultiple.svelte
+++ b/stories/svelte/src/SelectMultiple.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+	import StoryShell from './components/StoryShell.svelte'
+	import SelectMultipleContent from './views/SelectMultipleContent.svelte'
+</script>
+
+<StoryShell>
+	<SelectMultipleContent />
+</StoryShell>

--- a/stories/svelte/src/views/SelectMultipleContent.svelte
+++ b/stories/svelte/src/views/SelectMultipleContent.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+	import { useSelect } from '@ginjou/svelte'
+	import type { Post } from '@ginjou/storybook-shared/mock-data'
+	import Card from '../components/Card.svelte'
+	import FieldLabel from '../components/FieldLabel.svelte'
+	import Input from '../components/Input.svelte'
+	import PageTitle from '../components/PageTitle.svelte'
+	import Select from '../components/Select.svelte'
+	import Stack from '../components/Stack.svelte'
+
+	let value = $state<string[] | undefined>()
+
+	const select = useSelect<Post>(() => ({
+		resource: 'posts',
+		value,
+	}))
+</script>
+
+<Stack>
+	<PageTitle>useSelect</PageTitle>
+
+	<FieldLabel>
+		<span>Search</span>
+		<Input
+			placeholder="Keyword for option list"
+			bind:value={
+				() => select.search ?? '',
+				(v) => select.search = v || undefined
+			}
+		/>
+	</FieldLabel>
+
+	<FieldLabel>
+		<span>Posts</span>
+		<Select
+			multiple
+			size={5}
+			bind:value={
+				() => value ?? [],
+				(v) => value = v.length ? v : undefined
+			}
+		>
+			{#each select.options ?? [] as option}
+				<option value={`${option.value}`}>{option.label}</option>
+			{/each}
+		</Select>
+	</FieldLabel>
+
+	<Card>Selected value: {value ?? 'None'}</Card>
+</Stack>

--- a/stories/vue/src/Select.stories.ts
+++ b/stories/vue/src/Select.stories.ts
@@ -2,15 +2,36 @@ import type { Meta, StoryObj } from '@storybook/vue3-vite'
 import { createPostHandlers } from '@ginjou/storybook-shared/mock-data'
 import { h } from 'vue'
 import SelectBasic from './SelectBasic.vue'
+import SelectMultiple from './SelectMultiple.vue'
 import { createWrapper } from './utils/wrapper'
 
 const meta = {
+	component: SelectBasic,
 	title: 'Controllers/Select',
-} satisfies Meta
+} satisfies Meta<typeof SelectBasic>
 
 export const Basic = {
 	name: 'Basic',
 	render: () => () => h(SelectBasic),
+	parameters: {
+		msw: {
+			handlers: createPostHandlers(),
+		},
+	},
+	decorators: [
+		createWrapper({
+			resources: [
+				{
+					name: 'posts',
+				},
+			],
+		}),
+	],
+} satisfies StoryObj<typeof meta>
+
+export const Multiple = {
+	name: 'Multiple',
+	render: () => () => h(SelectMultiple),
 	parameters: {
 		msw: {
 			handlers: createPostHandlers(),

--- a/stories/vue/src/SelectMultiple.vue
+++ b/stories/vue/src/SelectMultiple.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+import type { Post } from './api/posts'
+import { useSelect } from '@ginjou/vue'
+import { ref } from 'vue'
+import Card from './components/Card.vue'
+import FieldLabel from './components/FieldLabel.vue'
+import Input from './components/Input.vue'
+import PageTitle from './components/PageTitle.vue'
+import Select from './components/Select.vue'
+import Stack from './components/Stack.vue'
+import StoryShell from './components/StoryShell.vue'
+
+const value = ref<string[]>()
+
+const {
+	options,
+	search,
+} = useSelect<Post>({
+	resource: 'posts',
+	value,
+})
+</script>
+
+<template>
+	<StoryShell>
+		<Stack>
+			<PageTitle>useSelect</PageTitle>
+
+			<FieldLabel>
+				<span>Search</span>
+				<Input v-model="search" placeholder="Keyword for option list" />
+			</FieldLabel>
+			<FieldLabel>
+				<span>Posts</span>
+				<Select
+					v-model="value"
+					multiple
+					:size="5"
+				>
+					<option
+						v-for="opt in options"
+						:key="opt.value"
+						:value="opt.value"
+					>
+						{{ opt.label }}
+					</option>
+				</Select>
+			</FieldLabel>
+
+			<Card>Selected value: {{ value ?? 'None' }}</Card>
+		</Stack>
+	</StoryShell>
+</template>

--- a/stories/vue/src/utils/wrapper.ts
+++ b/stories/vue/src/utils/wrapper.ts
@@ -1,6 +1,6 @@
 import type { Auth, Authz, Fetchers, I18n, Notification, Resource } from '@ginjou/core'
 import type { Decorator } from '@storybook/vue3'
-import type { QueryClient } from '@tanstack/vue-query'
+import type { QueryClient, QueryClientConfig } from '@tanstack/vue-query'
 import { defineAuth, defineAuthz, defineI18n, NotificationType } from '@ginjou/core'
 import { defineAuthContext, defineAuthzContext, defineControllerContext, defineFetchersContext, defineI18nContext, defineNotificationContext, defineQueryClientContext, defineRouterContext } from '@ginjou/vue'
 import { createFetcher } from '@ginjou/with-rest-api'
@@ -17,7 +17,7 @@ export type CreateWrapperProps
 		auth?: Auth | boolean
 		authz?: Authz | boolean
 		i18n?: I18n | boolean
-		queryClient?: QueryClient
+		queryClient?: QueryClient | QueryClientConfig
 		notification?: Notification | boolean
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Select controls now retrieve value-based options more reliably using dedicated query settings and metadata.
  * Improved consistency of select controller behavior across Vue and Svelte integrations.
  * Show views now correctly pass context when loading individual records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->