### PR TITLE
feat: dynamic meta for useGetManyByOne

### DIFF
--- a/packages/core/src/query/get-many-by-one.ts
+++ b/packages/core/src/query/get-many-by-one.ts
@@ -1,7 +1,7 @@
 import type { QueryClient, QueryObserverOptions, QueryObserverResult, RefetchOptions } from '@tanstack/query-core'
 import type { QueryCallbacks } from 'tanstack-query-callbacks'
-import type { SetOptional, Simplify } from 'type-fest'
-import type { BaseRecord, GetManyProps, GetManyResult, GetOneResult, RecordKey } from './fetcher'
+import type { Simplify } from 'type-fest'
+import type { BaseRecord, GetManyResult, GetOneResult, Meta, RecordKey } from './fetcher'
 import type { FetcherProps, Fetchers, ResolvedFetcherProps } from './fetchers'
 import { GetOne } from '.'
 import { resolveFetcherProps } from './fetchers'
@@ -24,17 +24,19 @@ export type QueryOptions<
 >
 
 export type QueryProps = Simplify<
-	& SetOptional<
-		GetManyProps,
-		| 'ids'
-		| 'resource'
-	>
 	& FetcherProps
+	& {
+		ids?: string[]
+		resource?: string
+	}
 >
 
 export type ResolvedQueryProps = Simplify<
-	& GetManyProps
 	& ResolvedFetcherProps
+	& {
+		ids: string[]
+		resource: string
+	}
 >
 
 export function resolveQueryProps(
@@ -44,7 +46,6 @@ export function resolveQueryProps(
 		...resolveFetcherProps(props),
 		ids: props.ids ?? [],
 		resource: props.resource ?? '',
-		meta: props.meta,
 	}
 }
 
@@ -71,6 +72,10 @@ export interface GenQueryOptionsForPropsInput {
 	index: number
 }
 
+export type GenQueryMetaFn = (input: GenQueryOptionsForPropsInput) =>
+	| Meta
+	| undefined
+
 export type Props<
 	TData extends BaseRecord,
 	TError,
@@ -78,6 +83,9 @@ export type Props<
 > = Simplify<
 	& QueryProps
 	& {
+		meta?:
+			| Meta
+			| GenQueryMetaFn
 		queryOptions?:
 			| QueryOptionsForProps<TData, TError, TResultData>
 			| GenQueryOptionsForPropsFn<TData, TError, TResultData>
@@ -90,6 +98,10 @@ export function getQueriesOptions<
 	TResultData extends BaseRecord,
 >(
 	props: {
+		meta:
+			| Meta
+			| GenQueryMetaFn
+			| undefined
 		queryProps: ResolvedQueryProps
 		fetchers: Fetchers
 		queryOptions:
@@ -100,8 +112,11 @@ export function getQueriesOptions<
 	},
 ): QueryObserverOptions<GetOneResult<TData>, TError, GetOneResult<TResultData>, GetOneResult<TData>>[] {
 	return props.queryProps.ids.map((id, index) => {
-		const propsForGetOne = resolveGetOneProps(id, props.queryProps)
 		const queryOptionsForProps = resolveQueryOptions({ id, index }, props.queryOptions)
+		const propsForGetOne = {
+			...resolveGetOneProps(id, props.queryProps),
+			meta: resolveQueryMeta({ id, index }, props.meta),
+		}
 		const queryKey = GetOne.createQueryKey({
 			props: propsForGetOne,
 		})
@@ -126,6 +141,18 @@ export function getQueriesOptions<
 			placeholderData: placeholderDataFn,
 		}
 	})
+}
+
+function resolveQueryMeta(
+	input: GenQueryOptionsForPropsInput,
+	meta:
+		| Meta
+		| GenQueryMetaFn
+		| undefined,
+): Meta | undefined {
+	if (typeof meta === 'function')
+		return meta(input)
+	return meta
 }
 
 export function createCombineFn<

--- a/packages/svelte/src/query/get-many-by-one.svelte.test.ts
+++ b/packages/svelte/src/query/get-many-by-one.svelte.test.ts
@@ -58,9 +58,6 @@ describe('useGetManyByOne', () => {
 		mocks.resolveQueryProps.mockReturnValue({
 			ids: ['1', '2'],
 			resource: 'posts',
-			meta: {
-				scope: 'admin',
-			},
 			fetcherName: 'default',
 		})
 		mocks.useFetchersContext.mockReturnValue({
@@ -90,18 +87,12 @@ describe('useGetManyByOne', () => {
 		expect(mocks.resolveQueryProps).toHaveBeenCalledWith({
 			ids: ['1', '2'],
 			resource: 'posts',
-			meta: {
-				scope: 'admin',
-			},
 			fetcherName: undefined,
 		})
 		expect(mocks.getQueriesOptions).toHaveBeenCalledWith({
 			queryProps: {
 				ids: ['1', '2'],
 				resource: 'posts',
-				meta: {
-					scope: 'admin',
-				},
 				fetcherName: 'default',
 			},
 			fetchers: {
@@ -110,6 +101,9 @@ describe('useGetManyByOne', () => {
 			queryOptions,
 			queryClient: {
 				name: 'query-client',
+			},
+			meta: {
+				scope: 'admin',
 			},
 		})
 

--- a/packages/svelte/src/query/get-many-by-one.svelte.test.ts
+++ b/packages/svelte/src/query/get-many-by-one.svelte.test.ts
@@ -4,19 +4,23 @@ import { useGetManyByOne } from './get-many-by-one.svelte'
 const mocks = vi.hoisted(() => ({
 	createCombineFn: vi.fn(),
 	createQueries: vi.fn(),
-	getQueriesOptions: vi.fn(),
 	resolveQueryProps: vi.fn(),
 	useFetchersContext: vi.fn(),
 	useQueryClientContext: vi.fn(),
 }))
 
-vi.mock('@ginjou/core', () => ({
-	GetManyByOne: {
-		createCombineFn: mocks.createCombineFn,
-		getQueriesOptions: mocks.getQueriesOptions,
-		resolveQueryProps: mocks.resolveQueryProps,
-	},
-}))
+vi.mock('@ginjou/core', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('@ginjou/core')>()
+
+	return {
+		...actual,
+		GetManyByOne: {
+			...actual.GetManyByOne,
+			createCombineFn: mocks.createCombineFn,
+			resolveQueryProps: mocks.resolveQueryProps,
+		},
+	}
+})
 
 vi.mock('@tanstack/svelte-query', () => ({
 	createQueries: mocks.createQueries,
@@ -34,7 +38,6 @@ describe('useGetManyByOne', () => {
 	beforeEach(() => {
 		mocks.createCombineFn.mockReset()
 		mocks.createQueries.mockReset()
-		mocks.getQueriesOptions.mockReset()
 		mocks.resolveQueryProps.mockReset()
 		mocks.useFetchersContext.mockReset()
 		mocks.useQueryClientContext.mockReset()
@@ -45,16 +48,6 @@ describe('useGetManyByOne', () => {
 				data: [{ id: '1' }, { id: '2' }],
 			},
 		})
-		mocks.getQueriesOptions.mockReturnValue([
-			{
-				queryKey: ['posts', '1'],
-				enabled: true,
-			},
-			{
-				queryKey: ['posts', '2'],
-				enabled: true,
-			},
-		])
 		mocks.resolveQueryProps.mockReturnValue({
 			ids: ['1', '2'],
 			resource: 'posts',
@@ -68,8 +61,12 @@ describe('useGetManyByOne', () => {
 		})
 	})
 
-	it('should expose records accessor and wire createQueries options', () => {
+	it('should expose records accessor, wire createQueries options, and forward static metadata', async () => {
 		const queryOptions = vi.fn()
+		const getOne = vi.fn().mockResolvedValue({ data: { id: '1' } })
+		mocks.useFetchersContext.mockReturnValue({
+			default: { getOne },
+		})
 
 		const result = useGetManyByOne({
 			ids: ['1', '2'],
@@ -89,37 +86,60 @@ describe('useGetManyByOne', () => {
 			resource: 'posts',
 			fetcherName: undefined,
 		})
-		expect(mocks.getQueriesOptions).toHaveBeenCalledWith({
-			queryProps: {
-				ids: ['1', '2'],
-				resource: 'posts',
-				fetcherName: 'default',
-			},
-			fetchers: {
-				default: {},
-			},
-			queryOptions,
-			queryClient: {
-				name: 'query-client',
-			},
-			meta: {
-				scope: 'admin',
-			},
-		})
-
-		expect(createQueriesOptions.queries).toEqual([
-			{
-				queryKey: ['posts', '1'],
-				enabled: true,
-			},
-			{
-				queryKey: ['posts', '2'],
-				enabled: true,
-			},
-		])
+		expect(createQueriesOptions.queries).toHaveLength(2)
 		expect(createQueriesOptions.combine).toBe(mocks.createCombineFn.mock.results[0]?.value)
 		expect(getQueryClient()).toEqual({
 			name: 'query-client',
 		})
+
+		await createQueriesOptions.queries[0].queryFn({})
+
+		expect(getOne).toHaveBeenCalledWith({
+			id: '1',
+			resource: 'posts',
+			fetcherName: 'default',
+			meta: {
+				scope: 'admin',
+			},
+		}, expect.any(Object))
+	})
+
+	it('should generate distinct metadata for each query and fetcher', async () => {
+		const getOne = vi.fn().mockResolvedValue({ data: { id: '1' } })
+		const meta = vi.fn(({ id, index }) => ({ id, index }))
+		mocks.useFetchersContext.mockReturnValue({
+			default: { getOne },
+		})
+
+		useGetManyByOne({
+			ids: ['1', '2'],
+			resource: 'posts',
+			meta,
+		} as any)
+
+		const queries = mocks.createQueries.mock.calls[0][0]().queries as {
+			queryFn: (context: object) => Promise<unknown>
+			queryKey: unknown[]
+		}[]
+		await Promise.all(queries.map(query => query.queryFn({})))
+
+		expect(meta).toHaveBeenNthCalledWith(1, { id: '1', index: 0 })
+		expect(meta).toHaveBeenNthCalledWith(2, { id: '2', index: 1 })
+		expect(queries.map(query => query.queryKey[query.queryKey.length - 1])).toEqual([
+			{ meta: { id: '1', index: 0 } },
+			{ meta: { id: '2', index: 1 } },
+		])
+		expect(getOne).toHaveBeenNthCalledWith(1, {
+			id: '1',
+			resource: 'posts',
+			fetcherName: 'default',
+			meta: { id: '1', index: 0 },
+		}, expect.any(Object))
+		expect(getOne).toHaveBeenNthCalledWith(2, {
+			id: '2',
+			resource: 'posts',
+			fetcherName: 'default',
+			meta: { id: '2', index: 1 },
+		}, expect.any(Object))
 	})
 })

--- a/packages/svelte/src/query/get-many-by-one.svelte.ts
+++ b/packages/svelte/src/query/get-many-by-one.svelte.ts
@@ -67,10 +67,10 @@ export function useGetManyByOne<
 	const queryProps = $derived.by(() => GetManyByOne.resolveQueryProps({
 		ids: extract(resolvedProps.ids),
 		resource: extract(resolvedProps.resource),
-		meta: extract(resolvedProps.meta),
 		fetcherName: extract(resolvedProps.fetcherName),
 	}))
 	const options = $derived.by(() => GetManyByOne.getQueriesOptions<TData, TError, TResultData>({
+		meta: resolvedProps.meta,
 		queryProps,
 		fetchers,
 		queryOptions: resolvedProps.queryOptions,

--- a/packages/vue/src/query/get-many-by-one.test.ts
+++ b/packages/vue/src/query/get-many-by-one.test.ts
@@ -206,6 +206,43 @@ describe('useGetManyByOne', () => {
 			fetcherName: 'default',
 		}, expect.any(Object))
 	})
+
+	it('should generate distinct metadata for each query and fetcher', async () => {
+		const meta = vi.fn(({ id, index }: { id: RecordKey, index: number }) => ({ id, index }))
+		const getOne = createGetOneMock()
+
+		const { result } = mountTestApp(
+			() => useGetManyByOne({
+				resource: 'posts',
+				ids: ['1', '2'],
+				meta,
+			}),
+			{
+				queryClient,
+				fetchers: createFetchers(getOne),
+			},
+		)
+
+		await vi.waitFor(() => {
+			expect(unref(result.isSuccess)).toBeTruthy()
+		})
+
+		expect(meta).toHaveBeenNthCalledWith(1, { id: '1', index: 0 })
+		expect(meta).toHaveBeenNthCalledWith(2, { id: '2', index: 1 })
+		expect(meta.mock.results[0]?.value).not.toBe(meta.mock.results[1]?.value)
+		expect(getOne).toHaveBeenNthCalledWith(1, {
+			resource: 'posts',
+			id: '1',
+			meta: { id: '1', index: 0 },
+			fetcherName: 'default',
+		}, expect.any(Object))
+		expect(getOne).toHaveBeenNthCalledWith(2, {
+			resource: 'posts',
+			id: '2',
+			meta: { id: '2', index: 1 },
+			fetcherName: 'default',
+		}, expect.any(Object))
+	})
 })
 
 function createFetchers(

--- a/packages/vue/src/query/get-many-by-one.ts
+++ b/packages/vue/src/query/get-many-by-one.ts
@@ -60,12 +60,12 @@ export function useGetManyByOne<
 	const queryProps = computed(() => GetManyByOne.resolveQueryProps({
 		ids: unref(props.ids),
 		resource: unref(props.resource),
-		meta: unref(props.meta),
 		fetcherName: unref(props.fetcherName),
 	}))
 	const options = computed(() => {
 		const queryOptions = unref(props.queryOptions)
 		return GetManyByOne.getQueriesOptions<TData, TError, TResultData>({
+			meta: unref(props.meta),
 			queryProps: unref(queryProps),
 			fetchers,
 			queryOptions,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for per-item query metadata in “get many by one” queries, allowing metadata to be either a fixed value or generated from each `{ id, index }`.
* **Bug Fixes**
  * Improved metadata and fetcher name handling so generated options correctly reflect per-item settings across Svelte and Vue.
* **Tests**
  * Extended coverage to verify per-item metadata generation and ensure the correct values are passed through for each queried id/index.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->