### PR TITLE
fix(rest-api): preserve custom body methods

### DIFF
--- a/packages/with-rest-api/src/fetchers.test.ts
+++ b/packages/with-rest-api/src/fetchers.test.ts
@@ -319,7 +319,7 @@ describe('createFetcher', () => {
 			// expect(methodUtil.toMethod).toHaveBeenCalledWith('post'); // Removed
 
 			expect(mockClient.raw).toHaveBeenCalledWith('/custom-endpoint', {
-				method: 'PUT', // Based on actual toMethod
+				method: 'POST', // Based on actual toMethod
 				query: {
 					_order: 'desc', // Based on actual genSorters
 					_sort: 'x', // Based on actual genSorters

--- a/packages/with-rest-api/src/utils/method.test.ts
+++ b/packages/with-rest-api/src/utils/method.test.ts
@@ -2,13 +2,10 @@ import { describe, expect, it } from 'vitest'
 import { toMethod } from './method'
 
 describe('toMethod', () => {
-	it('should return "PUT" for "put", "post", "patch"', () => {
+	it('should preserve body methods', () => {
 		expect(toMethod('put')).toBe('PUT')
-		expect(toMethod('post')).toBe('PUT')
-		expect(toMethod('patch')).toBe('PUT')
-	})
-
-	it('should return "DELETE" for "delete"', () => {
+		expect(toMethod('post')).toBe('POST')
+		expect(toMethod('patch')).toBe('PATCH')
 		expect(toMethod('delete')).toBe('DELETE')
 	})
 

--- a/packages/with-rest-api/src/utils/method.ts
+++ b/packages/with-rest-api/src/utils/method.ts
@@ -3,13 +3,10 @@ export function toMethod(
 ): string {
 	switch (method) {
 		case 'put':
-			return 'PUT'
 		case 'post':
-			return 'POST'
 		case 'patch':
-			return 'PATCH'
 		case 'delete':
-			return 'DELETE'
+			return method.toUpperCase()
 		default:
 			return 'GET'
 	}

--- a/packages/with-rest-api/src/utils/method.ts
+++ b/packages/with-rest-api/src/utils/method.ts
@@ -3,9 +3,11 @@ export function toMethod(
 ): string {
 	switch (method) {
 		case 'put':
-		case 'post':
-		case 'patch':
 			return 'PUT'
+		case 'post':
+			return 'POST'
+		case 'patch':
+			return 'PATCH'
 		case 'delete':
 			return 'DELETE'
 		default:


### PR DESCRIPTION
## Summary
- Preserve `post`, `put`, and `patch` as their corresponding HTTP methods.
- Keep the existing GET fallback for other custom methods.

## Why
The REST adapter incorrectly mapped POST and PATCH custom requests to PUT.

## Validation
- Vitest: 2 tests passed
- ESLint passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected HTTP method handling so POST and PATCH requests use their proper methods instead of being treated as PUT requests.
  * Updated custom request behavior to send fully configured requests with POST as expected.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->