### PR TITLE
fix(rest-api): send custom payload in body

### DIFF
--- a/packages/with-rest-api/src/fetchers.test.ts
+++ b/packages/with-rest-api/src/fetchers.test.ts
@@ -327,7 +327,7 @@ describe('createFetcher', () => {
 					customQ: 'query',
 				},
 				headers: customHeaders,
-				params: customPayload,
+				body: customPayload,
 			})
 			expect(result).toEqual({ data: mockData })
 		})
@@ -349,7 +349,7 @@ describe('createFetcher', () => {
 				method: 'GET',
 				query: {},
 				headers: undefined,
-				params: undefined,
+				body: undefined,
 			})
 			expect(result).toEqual({ data: mockData })
 		})

--- a/packages/with-rest-api/src/fetchers.ts
+++ b/packages/with-rest-api/src/fetchers.ts
@@ -131,7 +131,7 @@ export function createFetcher(
 				method: reqMethod,
 				query: reqQuery,
 				headers,
-				params: payload as any,
+				body: payload as any,
 			})
 
 			return {


### PR DESCRIPTION
## Summary
- Send custom mutation payloads through the HTTP request body.
- Keep query parameters reserved for URL parameters.

## Why
`ofetch` treats `params` as query-string data, so custom payloads were serialized into the URL instead of the request body.

## Validation
- Vitest: 19 tests passed
- ESLint passed