### PR TITLE
fix(vue): read create callbacks reactively

### DIFF
--- a/packages/vue/src/query/create.test.ts
+++ b/packages/vue/src/query/create.test.ts
@@ -1,12 +1,61 @@
 import { RealtimeAction } from '@ginjou/core'
 import { describe, expect, it, vi } from 'vitest'
-import { unref } from 'vue-demi'
+import { ref, unref } from 'vue-demi'
 import { MockFetchers, queryClient } from '../../test/mock-fetcher'
 import { MockRealtimes, publishFn } from '../../test/mock-realtime'
 import { mountTestApp } from '../../test/mount'
 import { useCreateOne } from './create'
 
 describe('useCreateOne', () => {
+	describe('mutation callbacks', () => {
+		it('should use the latest onSuccess callback', async () => {
+			const oldOnSuccess = vi.fn()
+			const onSuccess = vi.fn()
+			const mutationOptions = ref({ onSuccess: oldOnSuccess })
+			const { result } = mountTestApp(
+				() => useCreateOne({ mutationOptions }),
+				{
+					queryClient,
+					fetchers: MockFetchers,
+				},
+			)
+
+			mutationOptions.value = { onSuccess }
+			result.mutate({ resource: 'posts', params: {} })
+
+			await vi.waitFor(() => {
+				expect(onSuccess).toHaveBeenCalledOnce()
+			})
+			expect(oldOnSuccess).not.toHaveBeenCalled()
+		})
+
+		it('should use the latest onError callback', async () => {
+			const oldOnError = vi.fn()
+			const onError = vi.fn()
+			const mutationOptions = ref({ onError: oldOnError })
+			const { result } = mountTestApp(
+				() => useCreateOne({ mutationOptions }),
+				{
+					queryClient,
+					fetchers: {
+						default: {
+							...MockFetchers.default,
+							createOne: () => Promise.reject(new Error('No')),
+						},
+					},
+				},
+			)
+
+			mutationOptions.value = { onError }
+			result.mutate({ resource: 'posts', params: {} })
+
+			await vi.waitFor(() => {
+				expect(onError).toHaveBeenCalledOnce()
+			})
+			expect(oldOnError).not.toHaveBeenCalled()
+		})
+	})
+
 	describe('publish', () => {
 		it('should call realtime.publish', async () => {
 			const { result } = mountTestApp(

--- a/packages/vue/src/query/create.ts
+++ b/packages/vue/src/query/create.ts
@@ -77,7 +77,7 @@ export function useCreateOne<
 		translate,
 		publish,
 		getProps,
-		onSuccess: unref(props?.mutationOptions)?.onSuccess,
+		onSuccess: (...args) => unref(props?.mutationOptions)?.onSuccess?.(...args),
 		queryClient,
 	})
 	const handleError = CreateOne.createErrorHandler({
@@ -85,7 +85,7 @@ export function useCreateOne<
 		translate,
 		checkError,
 		getProps,
-		onError: unref(props?.mutationOptions)?.onError,
+		onError: (...args) => unref(props?.mutationOptions)?.onError?.(...args),
 	})
 
 	const mutation = useMutation<CreateResult<TData>, TError, CreateOne.MutationProps<TData, TError, TParams>, any>(


### PR DESCRIPTION
## Summary
- Read create callback handlers from reactive options at invocation time.
- Add regression coverage for callback updates.

## Why
The composable captured the initial callbacks, so later reactive changes were ignored.

## Validation
- Vitest: 4 tests passed
- ESLint passed