### PR TITLE
fix(stories): replace all vue i18n params

### DIFF
--- a/stories/vue/src/utils/wrapper.test.ts
+++ b/stories/vue/src/utils/wrapper.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest'
+import { createI18n } from './wrapper'
+
+describe('createI18n', () => {
+	it('keeps replacements made before unmatched params', () => {
+		expect(createI18n().translate('msg', {
+			name: 'Mark',
+			unused: 'value',
+		})).toBe('Hello Mark')
+	})
+})

--- a/stories/vue/src/utils/wrapper.ts
+++ b/stories/vue/src/utils/wrapper.ts
@@ -195,7 +195,7 @@ function createAuthz() {
 }
 
 // eslint-disable-next-line ts/explicit-function-return-type
-function createI18n() {
+export function createI18n() {
 	let locale = 'en-US'
 	const messages: Record<string, Record<string, string>> = {
 		'en-US': {
@@ -219,7 +219,7 @@ function createI18n() {
 
 			let result = raw
 			for (const [key, value] of Object.entries(params ?? {}))
-				result = raw.replace(`$${key}`, value)
+				result = result.replace(`$${key}`, value)
 
 			return result
 		},


### PR DESCRIPTION
## Summary
- Accumulate every Vue i18n parameter replacement.
- Add regression coverage for multiple parameters.

## Why
Each replacement started from the original source, so only the last parameter survived.

## Validation
- Vitest: 1 test passed
- ESLint passed
- Generated diff verified