### PR TITLE
test(core): require filter behavior to stay unused

### DIFF
--- a/packages/core/src/controller/list.test.ts
+++ b/packages/core/src/controller/list.test.ts
@@ -108,7 +108,7 @@ describe('list', () => {
 				{ field: 'name', operator: 'eq', value: 'John' },
 			], SetFilterBehavior.Replace)
 
-			expect(getFiltersBehavior).not.toHaveBeenCalledOnce()
+			expect(getFiltersBehavior).not.toHaveBeenCalled()
 			expect(update).toHaveBeenCalledOnce()
 
 			expect(update).toHaveBeenCalledWith([


### PR DESCRIPTION
## Summary

- Require filter behavior to remain unused with a never-called assertion.

## Why

The called-once matcher was too weak.

## Validation

- 10 tests passed
- Full ESLint passed