### PR TITLE
refactor(core): unify value union type names

### DIFF
--- a/packages/core/src/controller/list.ts
+++ b/packages/core/src/controller/list.ts
@@ -30,7 +30,7 @@ export type SortersProp
 export interface FiltersOptions {
 	value?: Filters
 	permanent?: Filters
-	behavior?: SetFilterBehaviorType
+	behavior?: SetFilterBehaviorValues
 	mode?: 'server' | 'off'
 }
 
@@ -571,11 +571,14 @@ export const SetFilterBehavior = {
 	Merge: 'merge',
 } as const
 
-export type SetFilterBehaviorType = ValueOf<typeof SetFilterBehavior>
+export type SetFilterBehaviorValues = ValueOf<typeof SetFilterBehavior>
+
+/** @deprecated Use SetFilterBehaviorValues instead. */
+export type SetFilterBehaviorType = SetFilterBehaviorValues
 
 export type SetFiltersFn = (
 	value: Filters | ((prev: Filters | undefined) => Filters),
-	behavior?: SetFilterBehaviorType,
+	behavior?: SetFilterBehaviorValues,
 ) => void
 
 export function createSetFiltersFn(

--- a/packages/core/src/controller/list.ts
+++ b/packages/core/src/controller/list.ts
@@ -573,9 +573,6 @@ export const SetFilterBehavior = {
 
 export type SetFilterBehaviorValues = ValueOf<typeof SetFilterBehavior>
 
-/** @deprecated Use SetFilterBehaviorValues instead. */
-export type SetFilterBehaviorType = SetFilterBehaviorValues
-
 export type SetFiltersFn = (
 	value: Filters | ((prev: Filters | undefined) => Filters),
 	behavior?: SetFilterBehaviorValues,

--- a/packages/core/src/query/create-many.ts
+++ b/packages/core/src/query/create-many.ts
@@ -6,7 +6,7 @@ import type { Notify } from '../notification'
 import type { Publish } from '../realtime'
 import type { BaseRecord, CreateManyFn, CreateManyProps, CreateManyResult, CreateOneFn, Params } from './fetcher'
 import type { FetcherProps, Fetchers, ResolvedFetcherProps } from './fetchers'
-import type { InvalidatesProps, InvalidateTargetType, ResolvedInvalidatesProps } from './invalidate'
+import type { InvalidatesProps, InvalidateTargetValues, ResolvedInvalidatesProps } from './invalidate'
 import type { NotifyProps } from './notify'
 import type { PublishPayload } from './publish'
 import type { OptionalMutateAsyncFunction, OptionalMutateSyncFunction, OriginMutateAsyncFunction, OriginMutateSyncFunction } from './types'
@@ -287,7 +287,7 @@ function createPublishEvent(
 	}
 }
 
-const DEFAULT_INVALIDATES: InvalidateTargetType[] = [
+const DEFAULT_INVALIDATES: InvalidateTargetValues[] = [
 	InvalidateTarget.List,
 	InvalidateTarget.Many,
 ]

--- a/packages/core/src/query/create.ts
+++ b/packages/core/src/query/create.ts
@@ -6,7 +6,7 @@ import type { Notify } from '../notification'
 import type { Publish } from '../realtime'
 import type { BaseRecord, CreateOneFn, CreateProps, CreateResult, Params } from './fetcher'
 import type { FetcherProps, Fetchers, ResolvedFetcherProps } from './fetchers'
-import type { InvalidatesProps, InvalidateTargetType, ResolvedInvalidatesProps } from './invalidate'
+import type { InvalidatesProps, InvalidateTargetValues, ResolvedInvalidatesProps } from './invalidate'
 import type { NotifyProps } from './notify'
 import type { PublishPayload } from './publish'
 import type { OptionalMutateAsyncFunction, OptionalMutateSyncFunction, OriginMutateAsyncFunction, OriginMutateSyncFunction } from './types'
@@ -282,7 +282,7 @@ function createPublishEvent(
 	}
 }
 
-const DEFAULT_INVALIDATES: InvalidateTargetType[] = [
+const DEFAULT_INVALIDATES: InvalidateTargetValues[] = [
 	InvalidateTarget.List,
 	InvalidateTarget.Many,
 ]

--- a/packages/core/src/query/delete-many.ts
+++ b/packages/core/src/query/delete-many.ts
@@ -6,7 +6,7 @@ import type { Notify } from '../notification'
 import type { Publish } from '../realtime'
 import type { BaseRecord, DeleteManyFn, DeleteManyProps, DeleteManyResult, DeleteOneFn, Params } from './fetcher'
 import type { FetcherProps, Fetchers, ResolvedFetcherProps } from './fetchers'
-import type { InvalidatesProps, InvalidateTargetType, ResolvedInvalidatesProps } from './invalidate'
+import type { InvalidatesProps, InvalidateTargetValues, ResolvedInvalidatesProps } from './invalidate'
 import type { MutationModeProps, ResolvedMutationModeProps } from './mutation-mode'
 import type { NotifyProps } from './notify'
 import type { OptimisticUpdateProps } from './optimistic-update'
@@ -472,7 +472,7 @@ function createPublishEvent(
 	}
 }
 
-const DEFAULT_INVALIDATES: InvalidateTargetType[] = [
+const DEFAULT_INVALIDATES: InvalidateTargetValues[] = [
 	InvalidateTarget.List,
 	InvalidateTarget.Many,
 ]

--- a/packages/core/src/query/delete.ts
+++ b/packages/core/src/query/delete.ts
@@ -6,7 +6,7 @@ import type { Notify } from '../notification'
 import type { Publish } from '../realtime'
 import type { BaseRecord, DeleteOneFn, DeleteOneProps, DeleteOneResult, Params } from './fetcher'
 import type { FetcherProps, Fetchers, ResolvedFetcherProps } from './fetchers'
-import type { InvalidatesProps, InvalidateTargetType, ResolvedInvalidatesProps } from './invalidate'
+import type { InvalidatesProps, InvalidateTargetValues, ResolvedInvalidatesProps } from './invalidate'
 import type { MutationModeProps, ResolvedMutationModeProps } from './mutation-mode'
 import type { NotifyProps } from './notify'
 import type { OptimisticUpdateProps } from './optimistic-update'
@@ -410,7 +410,7 @@ function createPublishEvent(
 	}
 }
 
-const DEFAULT_INVALIDATES: InvalidateTargetType[] = [
+const DEFAULT_INVALIDATES: InvalidateTargetValues[] = [
 	InvalidateTarget.List,
 	InvalidateTarget.Many,
 ]

--- a/packages/core/src/query/fetcher.ts
+++ b/packages/core/src/query/fetcher.ts
@@ -19,9 +19,6 @@ export const SortOrder = {
 
 export type SortOrderValues = ValueOf<typeof SortOrder>
 
-/** @deprecated Use SortOrderValues instead. */
-export type SortOrderType = SortOrderValues
-
 export function isSortOrder(
 	value: unknown,
 ): value is SortOrderValues {
@@ -78,9 +75,6 @@ export const FilterOperator = {
 } as const
 
 export type FilterOperatorValues = ValueOf<typeof FilterOperator>
-
-/** @deprecated Use FilterOperatorValues instead. */
-export type FilterOperatorType = FilterOperatorValues
 
 export interface LogicalFilter {
 	field: string

--- a/packages/core/src/query/fetcher.ts
+++ b/packages/core/src/query/fetcher.ts
@@ -17,11 +17,14 @@ export const SortOrder = {
 	Desc: 'desc',
 } as const
 
-export type SortOrderType = ValueOf<typeof SortOrder>
+export type SortOrderValues = ValueOf<typeof SortOrder>
+
+/** @deprecated Use SortOrderValues instead. */
+export type SortOrderType = SortOrderValues
 
 export function isSortOrder(
 	value: unknown,
-): value is SortOrderType {
+): value is SortOrderValues {
 	switch (value) {
 		case SortOrder.Asc:
 		case SortOrder.Desc:
@@ -33,7 +36,7 @@ export function isSortOrder(
 
 export interface Sort {
 	field: string
-	order: SortOrderType
+	order: SortOrderValues
 }
 
 export type Sorters = Sort[]
@@ -74,17 +77,20 @@ export const FilterOperator = {
 	and: 'and',
 } as const
 
-export type FilterOperatorType = ValueOf<typeof FilterOperator>
+export type FilterOperatorValues = ValueOf<typeof FilterOperator>
+
+/** @deprecated Use FilterOperatorValues instead. */
+export type FilterOperatorType = FilterOperatorValues
 
 export interface LogicalFilter {
 	field: string
-	operator: Exclude<FilterOperatorType, 'or' | 'and'>
+	operator: Exclude<FilterOperatorValues, 'or' | 'and'>
 	value: any
 }
 
 export interface ConditionalFilter {
 	key?: string
-	operator: Extract<FilterOperatorType, 'or' | 'and'>
+	operator: Extract<FilterOperatorValues, 'or' | 'and'>
 	value: (LogicalFilter | ConditionalFilter)[]
 }
 
@@ -94,7 +100,7 @@ export type Filters = Filter[]
 
 export function isFilterOperator(
 	operator: unknown,
-): operator is FilterOperatorType {
+): operator is FilterOperatorValues {
 	return (Object.values(FilterOperator) as unknown[]).includes(operator)
 }
 

--- a/packages/core/src/query/index.ts
+++ b/packages/core/src/query/index.ts
@@ -19,6 +19,7 @@ export * as GetOne from './get-one'
 export type {
 	InvalidatesProps,
 	InvalidateTargetType,
+	InvalidateTargetValues,
 } from './invalidate'
 export {
 	InvalidateTarget,

--- a/packages/core/src/query/index.ts
+++ b/packages/core/src/query/index.ts
@@ -18,7 +18,6 @@ export * as GetOne from './get-one'
 
 export type {
 	InvalidatesProps,
-	InvalidateTargetType,
 	InvalidateTargetValues,
 } from './invalidate'
 export {

--- a/packages/core/src/query/invalidate.ts
+++ b/packages/core/src/query/invalidate.ts
@@ -33,9 +33,6 @@ export const InvalidateTarget = {
 
 export type InvalidateTargetValues = ValueOf<typeof InvalidateTarget>
 
-/** @deprecated Use InvalidateTargetValues instead. */
-export type InvalidateTargetType = InvalidateTargetValues
-
 export type TriggerInvalidatesProps = Simplify<
 	& TriggerInvalidateProps
 	& {

--- a/packages/core/src/query/invalidate.ts
+++ b/packages/core/src/query/invalidate.ts
@@ -6,7 +6,7 @@ import { createQueryKey as genGetManyQueryKey } from './get-many'
 import { createQueryKey as genGetOneQueryKey } from './get-one'
 
 export interface InvalidatesProps {
-	invalidates?: InvalidateTargetType[]
+	invalidates?: InvalidateTargetValues[]
 }
 
 export type ResolvedInvalidatesProps = SetRequired<
@@ -16,7 +16,7 @@ export type ResolvedInvalidatesProps = SetRequired<
 
 export function resolveInvalidateProps(
 	props: InvalidatesProps,
-	defaultValue: InvalidateTargetType[],
+	defaultValue: InvalidateTargetValues[],
 ): ResolvedInvalidatesProps {
 	return {
 		invalidates: props.invalidates ?? defaultValue,
@@ -31,12 +31,15 @@ export const InvalidateTarget = {
 	One: 'one',
 } as const
 
-export type InvalidateTargetType = ValueOf<typeof InvalidateTarget>
+export type InvalidateTargetValues = ValueOf<typeof InvalidateTarget>
+
+/** @deprecated Use InvalidateTargetValues instead. */
+export type InvalidateTargetType = InvalidateTargetValues
 
 export type TriggerInvalidatesProps = Simplify<
 	& TriggerInvalidateProps
 	& {
-		invalidates: InvalidateTargetType[] | false
+		invalidates: InvalidateTargetValues[] | false
 	}
 >
 
@@ -197,7 +200,7 @@ export async function triggerInvalidate<
 	TResult extends BaseRecord,
 >(
 	props: any,
-	target: InvalidateTargetType,
+	target: InvalidateTargetValues,
 	result:
 		| GetOneResult<TResult>
 		| GetManyResult<TResult>

--- a/packages/core/src/query/update-many.ts
+++ b/packages/core/src/query/update-many.ts
@@ -6,7 +6,7 @@ import type { Notify } from '../notification'
 import type { Publish } from '../realtime'
 import type { BaseRecord, Params, UpdateManyFn, UpdateManyProps, UpdateManyResult, UpdateOneFn } from './fetcher'
 import type { FetcherProps, Fetchers, ResolvedFetcherProps } from './fetchers'
-import type { InvalidatesProps, InvalidateTargetType, ResolvedInvalidatesProps } from './invalidate'
+import type { InvalidatesProps, InvalidateTargetValues, ResolvedInvalidatesProps } from './invalidate'
 import type { MutationModeProps, ResolvedMutationModeProps } from './mutation-mode'
 import type { NotifyProps } from './notify'
 import type { OptimisticUpdateProps } from './optimistic-update'
@@ -469,7 +469,7 @@ function createPublishEvent(
 	}
 }
 
-const DEFAULT_INVALIDATES: InvalidateTargetType[] = [
+const DEFAULT_INVALIDATES: InvalidateTargetValues[] = [
 	InvalidateTarget.List,
 	InvalidateTarget.Many,
 	InvalidateTarget.One,

--- a/packages/core/src/query/update.ts
+++ b/packages/core/src/query/update.ts
@@ -6,7 +6,7 @@ import type { Notify } from '../notification'
 import type { Publish } from '../realtime'
 import type { BaseRecord, Params, UpdateOneFn, UpdateProps, UpdateResult } from './fetcher'
 import type { FetcherProps, Fetchers, ResolvedFetcherProps } from './fetchers'
-import type { InvalidatesProps, InvalidateTargetType, ResolvedInvalidatesProps } from './invalidate'
+import type { InvalidatesProps, InvalidateTargetValues, ResolvedInvalidatesProps } from './invalidate'
 import type { MutationModeProps, ResolvedMutationModeProps } from './mutation-mode'
 import type { NotifyProps } from './notify'
 import type { OptimisticUpdateProps } from './optimistic-update'
@@ -458,7 +458,7 @@ function createPublishEvent(
 	}
 }
 
-const DEFAULT_INVALIDATES: InvalidateTargetType[] = [
+const DEFAULT_INVALIDATES: InvalidateTargetValues[] = [
 	InvalidateTarget.List,
 	InvalidateTarget.Many,
 	InvalidateTarget.One,

--- a/packages/core/src/realtime/options.ts
+++ b/packages/core/src/realtime/options.ts
@@ -1,11 +1,11 @@
 import type { SetRequired, Simplify } from 'type-fest'
-import type { RealtimeModeValue, SubscribeCallbackFn } from './realtime'
+import type { RealtimeModeValues, SubscribeCallbackFn } from './realtime'
 import { RealtimeMode } from './realtime'
 
 export interface Input<
 	TPayload,
 > {
-	mode?: RealtimeModeValue
+	mode?: RealtimeModeValues
 	callback?: SubscribeCallbackFn<TPayload>
 	channel?: string
 	params?: Record<string, unknown>

--- a/packages/core/src/realtime/realtime.ts
+++ b/packages/core/src/realtime/realtime.ts
@@ -8,7 +8,10 @@ export const RealtimeMode = {
 	Manual: 'manual',
 } as const
 
-export type RealtimeModeValue = ValueOf<typeof RealtimeMode>
+export type RealtimeModeValues = ValueOf<typeof RealtimeMode>
+
+/** @deprecated Use RealtimeModeValues instead. */
+export type RealtimeModeValue = RealtimeModeValues
 
 export const RealtimeAction = {
 	Any: '*',

--- a/packages/core/src/realtime/realtime.ts
+++ b/packages/core/src/realtime/realtime.ts
@@ -10,9 +10,6 @@ export const RealtimeMode = {
 
 export type RealtimeModeValues = ValueOf<typeof RealtimeMode>
 
-/** @deprecated Use RealtimeModeValues instead. */
-export type RealtimeModeValue = RealtimeModeValues
-
 export const RealtimeAction = {
 	Any: '*',
 	Deleted: 'deleted',

--- a/packages/sync-route-compact/src/sorters.ts
+++ b/packages/sync-route-compact/src/sorters.ts
@@ -1,9 +1,9 @@
-import type { Sort, Sorters, SortOrderType } from '@ginjou/core'
+import type { Sort, Sorters, SortOrderValues } from '@ginjou/core'
 import { isSortOrder } from '@ginjou/core'
 import * as JSURL from 'jsurl2'
 import { invalid, parseArray, stringifyOptions } from './utils'
 
-type PackedSorter = [field: string, order: SortOrderType]
+type PackedSorter = [field: string, order: SortOrderValues]
 
 function packSorter(sorter: Sort): PackedSorter {
 	return [sorter.field, sorter.order]

--- a/packages/with-directus/src/fetcher.ts
+++ b/packages/with-directus/src/fetcher.ts
@@ -1,5 +1,5 @@
 import type { DirectusClient, RestClient } from '@directus/sdk'
-import type { ConditionalFilter, FilterOperatorType, Filters, LogicalFilter, Sorters } from '@ginjou/core'
+import type { ConditionalFilter, FilterOperatorValues, Filters, LogicalFilter, Sorters } from '@ginjou/core'
 import * as sdk from '@directus/sdk'
 import { defineFetcher, SortOrder } from '@ginjou/core'
 import cleanDeep from 'clean-deep'
@@ -268,7 +268,7 @@ function genConditionalFilter(
 }
 
 function getClientOperator(
-	operator: FilterOperatorType,
+	operator: FilterOperatorValues,
 ): string | undefined {
 	switch (operator) {
 		case 'eq':

--- a/packages/with-rest-api/src/utils/filters.ts
+++ b/packages/with-rest-api/src/utils/filters.ts
@@ -1,4 +1,4 @@
-import type { FilterOperatorType, Filters } from '@ginjou/core'
+import type { FilterOperatorValues, Filters } from '@ginjou/core'
 import { FilterOperator, isConditionalFilterOperator } from '@ginjou/core'
 
 export function genFilters(
@@ -32,7 +32,7 @@ export function genFilters(
 }
 
 function getOperator(
-	operator: FilterOperatorType,
+	operator: FilterOperatorValues,
 ): string {
 	switch (operator) {
 		case FilterOperator.ne:

--- a/packages/with-supabase/src/fetcher.ts
+++ b/packages/with-supabase/src/fetcher.ts
@@ -1,4 +1,4 @@
-import type { FilterOperatorType, Filters, Sorters } from '@ginjou/core'
+import type { FilterOperatorValues, Filters, Sorters } from '@ginjou/core'
 import type { PostgrestFilterBuilder } from '@supabase/postgrest-js'
 import type { SupabaseClient } from '@supabase/supabase-js'
 import { defineFetcher, isLogicalFilterOperator } from '@ginjou/core'
@@ -247,7 +247,7 @@ function applyFilters(
 }
 
 function getOperator(
-	operator: FilterOperatorType,
+	operator: FilterOperatorValues,
 ): string {
 	switch (operator) {
 		case 'ne':


### PR DESCRIPTION
## Summary

- Standardize public union types on the `Values` suffix.
- Retain deprecated aliases and update internal consumers.

## Why

The codebase used three competing suffix conventions.

## Validation

- Five package typechecks
- 23 tests passed
- ESLint passed