### PR TITLE
refactor(vue): align permissions context name

### DIFF
--- a/packages/nuxt/src/runtime/composables/permissions.ts
+++ b/packages/nuxt/src/runtime/composables/permissions.ts
@@ -1,4 +1,4 @@
-import type { UsePermissionsProps, UsePermissionsResult, UserPermissionsContext } from '@ginjou/vue'
+import type { UsePermissionsContext, UsePermissionsProps, UsePermissionsResult } from '@ginjou/vue'
 import type { AsyncResult } from '../utils/async'
 import { usePermissions } from '@ginjou/vue'
 import { withAsync } from '../utils/async'
@@ -9,7 +9,7 @@ export function useAsyncPermissions<
 	TError = unknown,
 >(
 	props?: UsePermissionsProps<TData, TParams, TError>,
-	context?: UserPermissionsContext,
+	context?: UsePermissionsContext,
 ): AsyncResult<UsePermissionsResult<TData, TError>> {
 	const query = usePermissions(props, context)
 	return withAsync(query, async () => {

--- a/packages/vue/src/authz/permissions.ts
+++ b/packages/vue/src/authz/permissions.ts
@@ -24,9 +24,6 @@ export type UsePermissionsContext = Simplify<
 	& UseQueryClientContextProps
 >
 
-/** @deprecated Use `UsePermissionsContext` instead. */
-export type UserPermissionsContext = UsePermissionsContext
-
 export type UsePermissionsResult<
 	TData,
 	TError,

--- a/packages/vue/src/authz/permissions.ts
+++ b/packages/vue/src/authz/permissions.ts
@@ -19,10 +19,13 @@ export type UsePermissionsProps<
 	Permissions.Props<TData, TParams, TError>
 >
 
-export type UserPermissionsContext = Simplify<
+export type UsePermissionsContext = Simplify<
 	& UseAuthzContextFromProps
 	& UseQueryClientContextProps
 >
+
+/** @deprecated Use `UsePermissionsContext` instead. */
+export type UserPermissionsContext = UsePermissionsContext
 
 export type UsePermissionsResult<
 	TData,
@@ -38,7 +41,7 @@ export function usePermissions<
 	TError = unknown,
 >(
 	props?: UsePermissionsProps<TData, TParams, TError>,
-	context?: UserPermissionsContext,
+	context?: UsePermissionsContext,
 ): UsePermissionsResult<TData, TError> {
 	const authz = useAuthzContext(context)
 	const queryClient = useQueryClientContext(context)


### PR DESCRIPTION
## Summary

- Expose `UsePermissionsContext` alias and align Nuxt usage.

## Why

The context name differed from composable naming.

## Validation

- 3 tests
- Typechecks
- ESLint