### PR TITLE
refactor(core)!: align single-record CRUD types

### DIFF
--- a/packages/core/src/controller/create.test.ts
+++ b/packages/core/src/controller/create.test.ts
@@ -1,4 +1,4 @@
-import type { BaseRecord, CreateResult } from '../query'
+import type { BaseRecord, CreateOneResult } from '../query'
 import type { Navigate } from '../router'
 import { describe, expect, it, vi } from 'vitest'
 import { createSaveFn, getIsLoading } from './create'
@@ -71,7 +71,7 @@ describe('create controller', () => {
 			const navigateTo = vi.fn()
 			const getResourceName = vi.fn(() => 'posts')
 			const getRedirect = vi.fn(() => undefined)
-			const mockData: CreateResult<BaseRecord> = {
+			const mockData: CreateOneResult<BaseRecord> = {
 				data: { id: 1, title: 'Test' },
 			}
 			const mutateFn = vi.fn().mockImplementation((_, options) => {
@@ -99,7 +99,7 @@ describe('create controller', () => {
 			const navigateTo = vi.fn()
 			const getResourceName = vi.fn(() => 'posts')
 			const getRedirect = vi.fn(() => ResourceAction.Type.Create)
-			const mockData: CreateResult<BaseRecord> = {
+			const mockData: CreateOneResult<BaseRecord> = {
 				data: { id: 1, title: 'Test' },
 			}
 			const mutateFn = vi.fn().mockImplementation((_, options) => {
@@ -127,7 +127,7 @@ describe('create controller', () => {
 			const navigateTo = vi.fn()
 			const getResourceName = vi.fn(() => 'posts')
 			const getRedirect = vi.fn(() => ResourceAction.Type.Edit)
-			const mockData: CreateResult<BaseRecord> = {
+			const mockData: CreateOneResult<BaseRecord> = {
 				data: { id: 1, title: 'Test' },
 			}
 			const mutateFn = vi.fn().mockImplementation((_, options) => {
@@ -156,7 +156,7 @@ describe('create controller', () => {
 			const navigateTo = vi.fn()
 			const getResourceName = vi.fn(() => 'posts')
 			const getRedirect = vi.fn(() => ResourceAction.Type.Show)
-			const mockData: CreateResult<BaseRecord> = {
+			const mockData: CreateOneResult<BaseRecord> = {
 				data: { id: 1, title: 'Test' },
 			}
 			const mutateFn = vi.fn().mockImplementation((_, options) => {
@@ -188,7 +188,7 @@ describe('create controller', () => {
 				to: '/custom/path',
 			}
 			const getRedirect = vi.fn(() => () => customNavProps)
-			const mockData: CreateResult<BaseRecord> = {
+			const mockData: CreateOneResult<BaseRecord> = {
 				data: { id: 1, title: 'Test' },
 			}
 			const mutateFn = vi.fn().mockImplementation((_, options) => {
@@ -214,7 +214,7 @@ describe('create controller', () => {
 			const getResourceName = vi.fn(() => 'posts')
 			const redirectFn = vi.fn(() => ResourceAction.Type.List)
 			const getRedirect = vi.fn(() => redirectFn)
-			const mockData: CreateResult<BaseRecord> = {
+			const mockData: CreateOneResult<BaseRecord> = {
 				data: { id: 1, title: 'Test' },
 			}
 			const mutateFn = vi.fn().mockImplementation((_, options) => {
@@ -238,11 +238,11 @@ describe('create controller', () => {
 		it('should handle redirect function returning different actions based on data', async () => {
 			const navigateTo = vi.fn()
 			const getResourceName = vi.fn(() => 'posts')
-			const redirectFn = vi.fn((data: CreateResult<BaseRecord>) => {
+			const redirectFn = vi.fn((data: CreateOneResult<BaseRecord>) => {
 				return data.data.id ? ResourceAction.Type.Edit : ResourceAction.Type.List
 			})
 			const getRedirect = vi.fn(() => redirectFn)
-			const mockData: CreateResult<BaseRecord> = {
+			const mockData: CreateOneResult<BaseRecord> = {
 				data: { id: 1, title: 'Test' },
 			}
 			const mutateFn = vi.fn().mockImplementation((_, options) => {
@@ -270,7 +270,7 @@ describe('create controller', () => {
 			const navigateTo = vi.fn()
 			const getResourceName = vi.fn(() => undefined)
 			const getRedirect = vi.fn(() => undefined)
-			const mockData: CreateResult<BaseRecord> = {
+			const mockData: CreateOneResult<BaseRecord> = {
 				data: { id: 1, title: 'Test' },
 			}
 			const mutateFn = vi.fn().mockImplementation((_, options) => {
@@ -298,7 +298,7 @@ describe('create controller', () => {
 			const navigateTo = vi.fn()
 			const getResourceName = vi.fn(() => 'posts')
 			const getRedirect = vi.fn(() => undefined)
-			const mockData: CreateResult<BaseRecord> = {
+			const mockData: CreateOneResult<BaseRecord> = {
 				data: { id: 1, title: 'Test' },
 			}
 			const mutateFn = vi.fn().mockResolvedValue(mockData)
@@ -337,7 +337,7 @@ describe('create controller', () => {
 			const navigateTo = vi.fn()
 			const getResourceName = vi.fn(() => 'posts')
 			const getRedirect = vi.fn(() => undefined)
-			const mockData: CreateResult<BaseRecord> = {
+			const mockData: CreateOneResult<BaseRecord> = {
 				data: { id: 1, title: 'Test', meta: { tags: ['a', 'b'] } },
 			}
 			const mutateFn = vi.fn().mockResolvedValue(mockData)
@@ -365,7 +365,7 @@ describe('create controller', () => {
 			const navigateTo = vi.fn()
 			const getResourceName = vi.fn(() => 'posts')
 			const getRedirect = vi.fn(() => ResourceAction.Type.List)
-			const mockData: CreateResult<BaseRecord> = {
+			const mockData: CreateOneResult<BaseRecord> = {
 				data: { title: 'Test' }, // No id
 			}
 			const mutateFn = vi.fn().mockImplementation((_, options) => {

--- a/packages/core/src/controller/create.ts
+++ b/packages/core/src/controller/create.ts
@@ -1,5 +1,5 @@
 import type { SetOptional } from 'type-fest'
-import type { BaseRecord, CreateResult, Params } from '../query'
+import type { BaseRecord, CreateOneResult, Params } from '../query'
 import type {
 	MutateAsyncFn as CreateMutateFn,
 	Props as CreateProps,
@@ -19,7 +19,7 @@ export type Props<
 		| 'params'
 	>
 	& {
-		redirect?: RedirectOptions<CreateResult<TMutationData>>
+		redirect?: RedirectOptions<CreateOneResult<TMutationData>>
 	},
 	'resource'
 >
@@ -39,7 +39,7 @@ export function getIsLoading(
 export type SaveFn<
 	TMutationData extends BaseRecord,
 	TMutationParams,
-> = (params: TMutationParams) => Promise<CreateResult<TMutationData>>
+> = (params: TMutationParams) => Promise<CreateOneResult<TMutationData>>
 
 export interface SaveFnParams<
 	TMutationData extends BaseRecord,
@@ -48,7 +48,7 @@ export interface SaveFnParams<
 > {
 	navigateTo: Navigate.ToFn
 	getResourceName: () => string | undefined
-	getRedirect: () => RedirectOptions<CreateResult<TMutationData>> | undefined
+	getRedirect: () => RedirectOptions<CreateOneResult<TMutationData>> | undefined
 	mutateFn: CreateMutateFn<TMutationData, TMutationError, TMutationParams>
 }
 

--- a/packages/core/src/controller/edit.test.ts
+++ b/packages/core/src/controller/edit.test.ts
@@ -1,4 +1,4 @@
-import type { BaseRecord, UpdateResult } from '../query'
+import type { BaseRecord, UpdateOneResult } from '../query'
 import type { Navigate } from '../router'
 import { describe, expect, it, vi } from 'vitest'
 import { MutationMode } from '../query'
@@ -147,7 +147,7 @@ describe('edit controller', () => {
 				const getRedirect = vi.fn(() => undefined)
 				const navigateTo = vi.fn()
 
-				const mockData: UpdateResult<BaseRecord> = {
+				const mockData: UpdateOneResult<BaseRecord> = {
 					data: { id: 1, title: 'Updated' },
 				}
 				const mutateFn = vi.fn().mockImplementation((_, options) => {
@@ -183,7 +183,7 @@ describe('edit controller', () => {
 				const getRedirect = vi.fn(() => undefined)
 				const navigateTo = vi.fn()
 
-				const mockData: UpdateResult<BaseRecord> = {
+				const mockData: UpdateOneResult<BaseRecord> = {
 					data: { id: 1, title: 'Updated' },
 				}
 				const mutateFn = vi.fn().mockImplementation((_, options) => {
@@ -242,7 +242,7 @@ describe('edit controller', () => {
 				const getRedirect = vi.fn(() => undefined)
 				const navigateTo = vi.fn()
 
-				const mockData: UpdateResult<BaseRecord> = {
+				const mockData: UpdateOneResult<BaseRecord> = {
 					data: { id: 1, title: 'Updated' },
 				}
 				const mutateFn = vi.fn().mockResolvedValue(mockData)
@@ -281,7 +281,7 @@ describe('edit controller', () => {
 				const getRedirect = vi.fn(() => undefined)
 				const navigateTo = vi.fn()
 
-				const mockData: UpdateResult<BaseRecord> = {
+				const mockData: UpdateOneResult<BaseRecord> = {
 					data: { id: 1, title: 'Updated' },
 				}
 				const mutateFn = vi.fn().mockResolvedValue(mockData)
@@ -319,7 +319,7 @@ describe('edit controller', () => {
 				const getRedirect = vi.fn(() => undefined)
 				const navigateTo = vi.fn()
 
-				const mockData: UpdateResult<BaseRecord> = {
+				const mockData: UpdateOneResult<BaseRecord> = {
 					data: { id: 1, title: 'Updated' },
 				}
 				const mutateFn = vi.fn().mockResolvedValue(mockData)
@@ -358,7 +358,7 @@ describe('edit controller', () => {
 				const getRedirect = vi.fn(() => undefined)
 				const navigateTo = vi.fn()
 
-				const mockData: UpdateResult<BaseRecord> = {
+				const mockData: UpdateOneResult<BaseRecord> = {
 					data: { id: 1, title: 'Updated' },
 				}
 				const mutateFn = vi.fn().mockResolvedValue(mockData)
@@ -392,7 +392,7 @@ describe('edit controller', () => {
 				const getRedirect = vi.fn(() => ResourceAction.Type.List)
 				const navigateTo = vi.fn()
 
-				const mockData: UpdateResult<BaseRecord> = {
+				const mockData: UpdateOneResult<BaseRecord> = {
 					data: { id: 1, title: 'Updated' },
 				}
 				const mutateFn = vi.fn().mockImplementation((_, options) => {
@@ -424,7 +424,7 @@ describe('edit controller', () => {
 				const getMutationMode = vi.fn(() => MutationMode.Pessimistic)
 				const getRedirect = vi.fn(() => ResourceAction.Type.Create)
 				const navigateTo = vi.fn()
-				const mockData: UpdateResult<BaseRecord> = {
+				const mockData: UpdateOneResult<BaseRecord> = {
 					data: { id: 1, title: 'Updated' },
 				}
 
@@ -458,7 +458,7 @@ describe('edit controller', () => {
 				const getRedirect = vi.fn(() => ResourceAction.Type.Edit)
 				const navigateTo = vi.fn()
 
-				const mockData: UpdateResult<BaseRecord> = {
+				const mockData: UpdateOneResult<BaseRecord> = {
 					data: { id: 1, title: 'Updated' },
 				}
 				const mutateFn = vi.fn().mockImplementation((_, options) => {
@@ -495,7 +495,7 @@ describe('edit controller', () => {
 				const getRedirect = vi.fn(() => () => customNavProps)
 
 				const navigateTo = vi.fn()
-				const mockData: UpdateResult<BaseRecord> = {
+				const mockData: UpdateOneResult<BaseRecord> = {
 					data: { id: 1, title: 'Updated' },
 				}
 				const mutateFn = vi.fn().mockImplementation((_, options) => {
@@ -526,7 +526,7 @@ describe('edit controller', () => {
 				const getRedirect = vi.fn(() => redirectFn)
 
 				const navigateTo = vi.fn()
-				const mockData: UpdateResult<BaseRecord> = {
+				const mockData: UpdateOneResult<BaseRecord> = {
 					data: { id: 1, title: 'Updated' },
 				}
 				const mutateFn = vi.fn().mockImplementation((_, options) => {
@@ -558,7 +558,7 @@ describe('edit controller', () => {
 			const getRedirect = vi.fn(() => undefined)
 
 			const navigateTo = vi.fn()
-			const mockData: UpdateResult<BaseRecord> = {
+			const mockData: UpdateOneResult<BaseRecord> = {
 				data: { id: 1, title: 'Updated' },
 			}
 			const mutateFn = vi.fn().mockResolvedValue(mockData)
@@ -635,7 +635,7 @@ describe('edit controller', () => {
 			const getRedirect = vi.fn(() => undefined)
 
 			const navigateTo = vi.fn()
-			const mockData: UpdateResult<BaseRecord> = {
+			const mockData: UpdateOneResult<BaseRecord> = {
 				data: { id: 1, title: 'Updated' },
 			}
 			const mutateFn = vi.fn().mockImplementation((_, options) => {
@@ -669,7 +669,7 @@ describe('edit controller', () => {
 			const getRedirect = vi.fn(() => undefined)
 
 			const navigateTo = vi.fn()
-			const mockData: UpdateResult<BaseRecord> = {
+			const mockData: UpdateOneResult<BaseRecord> = {
 				data: { id: 1, title: 'Updated', meta: { tags: ['a', 'b'] } },
 			}
 			const mutateFn = vi.fn().mockResolvedValue(mockData)
@@ -703,7 +703,7 @@ describe('edit controller', () => {
 			const getRedirect = vi.fn(() => undefined)
 
 			const navigateTo = vi.fn()
-			const mockData: UpdateResult<BaseRecord> = {
+			const mockData: UpdateOneResult<BaseRecord> = {
 				data: { id: 'abc-123', title: 'Updated' },
 			}
 			const mutateFn = vi.fn().mockImplementation((_, options) => {

--- a/packages/core/src/controller/edit.ts
+++ b/packages/core/src/controller/edit.ts
@@ -1,5 +1,5 @@
 import type { SetOptional } from 'type-fest'
-import type { BaseRecord, GetOneResult, Meta, MutationModeValues, Params, RecordKey, UpdateResult } from '../query'
+import type { BaseRecord, GetOneResult, Meta, MutationModeValues, Params, RecordKey, UpdateOneResult } from '../query'
 import type { Props as GetOneProps } from '../query/get-one'
 import type {
 	MutateAsyncFn as UpdateMutateFn,
@@ -25,7 +25,7 @@ export type Props<
 		| 'params'
 	>
 	& {
-		redirect?: RedirectOptions<UpdateResult<TMutationData>>
+		redirect?: RedirectOptions<UpdateOneResult<TMutationData>>
 		queryMeta?: Meta
 		queryOptions?: GetOneProps<TQueryData, TQueryError, TQueryResultData>['queryOptions']
 	},
@@ -66,7 +66,7 @@ export function getIsLoading(
 export type SaveFn<
 	TMutationParams,
 	TMutationData extends BaseRecord,
-> = (params: TMutationParams) => Promise<UpdateResult<TMutationData>>
+> = (params: TMutationParams) => Promise<UpdateOneResult<TMutationData>>
 
 export interface SaveFnParams<
 	TMutationParams extends Params,
@@ -77,7 +77,7 @@ export interface SaveFnParams<
 	getId: () => RecordKey | undefined
 	getResourceName: () => string | undefined
 	getMutationMode: () => MutationModeValues | undefined
-	getRedirect: () => RedirectOptions<UpdateResult<TMutationData>> | undefined
+	getRedirect: () => RedirectOptions<UpdateOneResult<TMutationData>> | undefined
 	getQueryData: () => GetOneResult<TQueryResultData> | undefined
 	navigateTo: Navigate.ToFn
 	mutateFn: UpdateMutateFn<TMutationData, TMutationError, TMutationParams>

--- a/packages/core/src/query/create.ts
+++ b/packages/core/src/query/create.ts
@@ -4,7 +4,7 @@ import type { CheckError } from '../auth'
 import type { Translate } from '../i18n'
 import type { Notify } from '../notification'
 import type { Publish } from '../realtime'
-import type { BaseRecord, CreateOneFn, CreateProps, CreateResult, Params } from './fetcher'
+import type { BaseRecord, CreateOneFn, CreateOneProps, CreateOneResult, Params } from './fetcher'
 import type { FetcherProps, Fetchers, ResolvedFetcherProps } from './fetchers'
 import type { InvalidatesProps, InvalidateTargetType, ResolvedInvalidatesProps } from './invalidate'
 import type { NotifyProps } from './notify'
@@ -23,10 +23,10 @@ export type MutationProps<
 	TError,
 	TParams extends Params,
 > = Simplify<
-	& Partial<CreateProps<TParams>>
+	& Partial<CreateOneProps<TParams>>
 	& FetcherProps
 	& InvalidatesProps
-	& NotifyProps<CreateResult<TData>, CreateProps<TParams>, TError>
+	& NotifyProps<CreateOneResult<TData>, CreateOneProps<TParams>, TError>
 >
 
 export type ResolvedMutationProps<
@@ -36,7 +36,7 @@ export type ResolvedMutationProps<
 > = Simplify<
 	& OverrideProperties<
 		MutationProps<TData, TError, TParams>,
-		CreateProps<TParams>
+		CreateOneProps<TParams>
 	>
 	& ResolvedFetcherProps
 	& ResolvedInvalidatesProps
@@ -47,7 +47,7 @@ export type MutationOptions<
 	TError,
 	TParams extends Params,
 > = MutationObserverOptions<
-	CreateResult<TData>,
+	CreateOneResult<TData>,
 	TError,
 	MutationProps<TData, TError, TParams>
 >
@@ -77,7 +77,7 @@ export type MutateFn<
 	TError,
 	TParams extends Params,
 > = OptionalMutateSyncFunction<
-	CreateResult<TData>,
+	CreateOneResult<TData>,
 	TError,
 	MutationProps<TData, TError, TParams>
 >
@@ -87,7 +87,7 @@ export type MutateAsyncFn<
 	TError,
 	TParams extends Params,
 > = OptionalMutateAsyncFunction<
-	CreateResult<TData>,
+	CreateOneResult<TData>,
 	TError,
 	MutationProps<TData, TError, TParams>
 >
@@ -221,7 +221,7 @@ export interface CreateMutateFnProps<
 	TParams extends Params,
 > {
 	originFn: OriginMutateSyncFunction<
-		CreateResult<TData>,
+		CreateOneResult<TData>,
 		TError,
 		MutationProps<TData, TError, TParams>
 	>
@@ -247,7 +247,7 @@ export interface CreateMutateAsyncFnProps<
 	TParams extends Params,
 > {
 	originFn: OriginMutateAsyncFunction<
-		CreateResult<TData>,
+		CreateOneResult<TData>,
 		TError,
 		MutationProps<TData, TError, TParams>
 	>
@@ -269,7 +269,7 @@ export function createMutateAsyncFn<
 
 function createPublishEvent(
 	resolvedProps: ResolvedMutationProps<any, any, any>,
-	data: CreateResult<any>,
+	data: CreateOneResult<any>,
 ): Publish.EmitEvent<PublishPayload> {
 	const payload = createPublishPayloadByOne(resolvedProps, data)
 	const meta = createPublishMeta(resolvedProps)
@@ -312,7 +312,7 @@ function resolveProps<
 >(
 	propsFromProps: Props<TData, TError, TParams> | undefined,
 	propsFromFn: MutationProps<TData, TError, TParams>,
-): OverrideProperties<MutationProps<TData, TError, TParams>, CreateProps<TParams>> {
+): OverrideProperties<MutationProps<TData, TError, TParams>, CreateOneProps<TParams>> {
 	const props = {
 		...propsFromProps,
 		...propsFromFn,

--- a/packages/core/src/query/fetcher.ts
+++ b/packages/core/src/query/fetcher.ts
@@ -144,7 +144,7 @@ export type Cursor<
 		| CursorOnlyPrev<TPageParam>
 		| CursorBi<TPageParam>
 
-export interface CreateProps<
+export interface CreateOneProps<
 	TParams extends Params,
 > {
 	resource: string
@@ -152,19 +152,25 @@ export interface CreateProps<
 	meta?: Meta
 }
 
-export interface CreateResult<
+export interface CreateOneResult<
 	TData extends BaseRecord,
 > {
 	data: TData
 }
 
+/** @deprecated Use CreateOneProps instead. */
+export type CreateProps<TParams extends Params> = CreateOneProps<TParams>
+
+/** @deprecated Use CreateOneResult instead. */
+export type CreateResult<TData extends BaseRecord> = CreateOneResult<TData>
+
 export type CreateOneFn<
 	TData extends BaseRecord,
 	TParams extends Params,
 > = (
-	props: CreateProps<TParams>,
+	props: CreateOneProps<TParams>,
 	context?: MutationFunctionContext,
-) => Promise<CreateResult<TData>>
+) => Promise<CreateOneResult<TData>>
 
 export interface CreateManyProps<
 	TParams extends Params,
@@ -270,13 +276,13 @@ export type CustomFn<
 	context?: QueryFunctionContext | MutationFunctionContext,
 ) => Promise<CustomResult<TData>>
 
-export interface UpdateResult<
+export interface UpdateOneResult<
 	TData extends BaseRecord,
 > {
 	data: TData
 }
 
-export interface UpdateProps<
+export interface UpdateOneProps<
 	TParams extends Params,
 > {
 	resource: string
@@ -285,13 +291,19 @@ export interface UpdateProps<
 	meta?: Meta
 }
 
+/** @deprecated Use UpdateOneProps instead. */
+export type UpdateProps<TParams extends Params> = UpdateOneProps<TParams>
+
+/** @deprecated Use UpdateOneResult instead. */
+export type UpdateResult<TData extends BaseRecord> = UpdateOneResult<TData>
+
 export type UpdateOneFn<
 	TData extends BaseRecord,
 	TParams extends Params,
 > = (
-	props: UpdateProps<TParams>,
+	props: UpdateOneProps<TParams>,
 	context?: MutationFunctionContext,
-) => Promise<UpdateResult<TData>>
+) => Promise<UpdateOneResult<TData>>
 
 export interface UpdateManyProps<
 	TParams extends Params,

--- a/packages/core/src/query/fetcher.ts
+++ b/packages/core/src/query/fetcher.ts
@@ -158,12 +158,6 @@ export interface CreateOneResult<
 	data: TData
 }
 
-/** @deprecated Use CreateOneProps instead. */
-export type CreateProps<TParams extends Params> = CreateOneProps<TParams>
-
-/** @deprecated Use CreateOneResult instead. */
-export type CreateResult<TData extends BaseRecord> = CreateOneResult<TData>
-
 export type CreateOneFn<
 	TData extends BaseRecord,
 	TParams extends Params,
@@ -290,12 +284,6 @@ export interface UpdateOneProps<
 	params: TParams
 	meta?: Meta
 }
-
-/** @deprecated Use UpdateOneProps instead. */
-export type UpdateProps<TParams extends Params> = UpdateOneProps<TParams>
-
-/** @deprecated Use UpdateOneResult instead. */
-export type UpdateResult<TData extends BaseRecord> = UpdateOneResult<TData>
 
 export type UpdateOneFn<
 	TData extends BaseRecord,

--- a/packages/core/src/query/invalidate.ts
+++ b/packages/core/src/query/invalidate.ts
@@ -1,6 +1,6 @@
 import type { InvalidateOptions, InvalidateQueryFilters, QueryClient } from '@tanstack/query-core'
 import type { SetRequired, Simplify, ValueOf } from 'type-fest'
-import type { BaseRecord, CreateManyResult, CreateResult, DeleteManyResult, DeleteOneResult, GetManyResult, GetOneResult, RecordKey, UpdateManyResult, UpdateResult } from './fetcher'
+import type { BaseRecord, CreateManyResult, CreateOneResult, DeleteManyResult, DeleteOneResult, GetManyResult, GetOneResult, RecordKey, UpdateManyResult, UpdateOneResult } from './fetcher'
 import { createQueryKey as genGetListQueryKey } from './get-list'
 import { createQueryKey as genGetManyQueryKey } from './get-many'
 import { createQueryKey as genGetOneQueryKey } from './get-one'
@@ -47,9 +47,9 @@ export async function triggerInvalidates<
 	result:
 		| GetOneResult<TResult>
 		| GetManyResult<TResult>
-		| CreateResult<TResult>
+		| CreateOneResult<TResult>
 		| CreateManyResult<TResult>
-		| UpdateResult<TResult>
+		| UpdateOneResult<TResult>
 		| UpdateManyResult<TResult>
 		| DeleteOneResult<TResult>
 		| DeleteManyResult<TResult>
@@ -183,9 +183,9 @@ export async function triggerInvalidate<
 	result:
 		| GetOneResult<TResult>
 		| GetManyResult<TResult>
-		| CreateResult<TResult>
+		| CreateOneResult<TResult>
 		| CreateManyResult<TResult>
-		| UpdateResult<TResult>
+		| UpdateOneResult<TResult>
 		| UpdateManyResult<TResult>
 		| DeleteOneResult<TResult>
 		| DeleteManyResult<TResult>
@@ -201,9 +201,9 @@ export async function triggerInvalidate<
 	result:
 		| GetOneResult<TResult>
 		| GetManyResult<TResult>
-		| CreateResult<TResult>
+		| CreateOneResult<TResult>
 		| CreateManyResult<TResult>
-		| UpdateResult<TResult>
+		| UpdateOneResult<TResult>
 		| UpdateManyResult<TResult>
 		| DeleteOneResult<TResult>
 		| DeleteManyResult<TResult>

--- a/packages/core/src/query/publish.ts
+++ b/packages/core/src/query/publish.ts
@@ -1,4 +1,4 @@
-import type { CreateManyResult, CreateResult, DeleteManyResult, DeleteOneResult, Meta, RecordKey, UpdateManyResult, UpdateResult } from './fetcher'
+import type { CreateManyResult, CreateOneResult, DeleteManyResult, DeleteOneResult, Meta, RecordKey, UpdateManyResult, UpdateOneResult } from './fetcher'
 import { uniq } from 'es-toolkit'
 
 export interface PublishPayload {
@@ -9,7 +9,7 @@ export function createPublishPayloadByOne(
 	props: {
 		id: RecordKey
 	} | Record<string, any>,
-	data: CreateResult<any> | UpdateResult<any> | DeleteOneResult<any>,
+	data: CreateOneResult<any> | UpdateOneResult<any> | DeleteOneResult<any>,
 ): PublishPayload {
 	const idFromProp = 'id' in props ? props.id : undefined
 	const idFromData = data.data.id

--- a/packages/core/src/query/update.ts
+++ b/packages/core/src/query/update.ts
@@ -4,7 +4,7 @@ import type { CheckError } from '../auth'
 import type { Translate } from '../i18n'
 import type { Notify } from '../notification'
 import type { Publish } from '../realtime'
-import type { BaseRecord, Params, UpdateOneFn, UpdateProps, UpdateResult } from './fetcher'
+import type { BaseRecord, Params, UpdateOneFn, UpdateOneProps, UpdateOneResult } from './fetcher'
 import type { FetcherProps, Fetchers, ResolvedFetcherProps } from './fetchers'
 import type { InvalidatesProps, InvalidateTargetType, ResolvedInvalidatesProps } from './invalidate'
 import type { MutationModeProps, ResolvedMutationModeProps } from './mutation-mode'
@@ -32,12 +32,12 @@ export type MutationProps<
 	TError,
 	TParams extends Params,
 > = Simplify<
-	& Partial<UpdateProps<TParams>>
+	& Partial<UpdateOneProps<TParams>>
 	& FetcherProps
 	& InvalidatesProps
-	& NotifyProps<UpdateResult<TData>, UpdateProps<TParams>, TError>
+	& NotifyProps<UpdateOneResult<TData>, UpdateOneProps<TParams>, TError>
 	& MutationModeProps
-	& OptimisticUpdateProps<TData, TParams, UpdateProps<TParams>['id']>
+	& OptimisticUpdateProps<TData, TParams, UpdateOneProps<TParams>['id']>
 >
 
 export type ResolvedMutationProps<
@@ -47,7 +47,7 @@ export type ResolvedMutationProps<
 > = Simplify<
 	& OverrideProperties<
 		MutationProps<TData, TError, TParams>,
-		UpdateProps<TParams>
+		UpdateOneProps<TParams>
 	>
 	& ResolvedFetcherProps
 	& ResolvedInvalidatesProps
@@ -65,7 +65,7 @@ export type MutationOptions<
 	TError,
 	TParams extends Params,
 > = MutationObserverOptions<
-	UpdateResult<TData>,
+	UpdateOneResult<TData>,
 	TError,
 	MutationProps<TData, TError, TParams>,
 	MutationContext<TData>
@@ -96,7 +96,7 @@ export type MutateFn<
 	TError,
 	TParams extends Params,
 > = OptionalMutateSyncFunction<
-	UpdateResult<TData>,
+	UpdateOneResult<TData>,
 	TError,
 	MutationProps<TData, TError, TParams>,
 	MutationContext<TData>
@@ -107,7 +107,7 @@ export type MutateAsyncFn<
 	TError,
 	TParams extends Params,
 > = OptionalMutateAsyncFunction<
-	UpdateResult<TData>,
+	UpdateOneResult<TData>,
 	TError,
 	MutationProps<TData, TError, TParams>,
 	MutationContext<TData>
@@ -139,7 +139,7 @@ export function createMutationFn<
 	return async function mutationFn(props, context) {
 		const resolvedProps = resolveMutationProps(getProps(), props)
 		const updateOne = getFetcherFn(resolvedProps, fetchers, 'updateOne') as UpdateOneFn<TData, TParams>
-		const executeFn = (): Promise<UpdateResult<TData>> => updateOne(resolvedProps, context)
+		const executeFn = (): Promise<UpdateOneResult<TData>> => updateOne(resolvedProps, context)
 
 		switch (resolvedProps.mutationMode) {
 			case MutationMode.Undoable: {
@@ -220,7 +220,7 @@ export function createMutateHandler<
 					dispatchSuccessNotify(
 						notify,
 						translate,
-						{ data: resolvedProps.params } as unknown as UpdateResult<TData>,
+						{ data: resolvedProps.params } as unknown as UpdateOneResult<TData>,
 						resolvedProps,
 					)
 				}, 0)
@@ -395,7 +395,7 @@ export interface CreateMutateFnProps<
 	TParams extends Params,
 > {
 	originFn: OriginMutateSyncFunction<
-		UpdateResult<TData>,
+		UpdateOneResult<TData>,
 		TError,
 		MutationProps<TData, TError, TParams>,
 		MutationContext<TData>
@@ -422,7 +422,7 @@ export interface CreateMutateAsyncFnProps<
 	TParams extends Params,
 > {
 	originFn: OriginMutateAsyncFunction<
-		UpdateResult<TData>,
+		UpdateOneResult<TData>,
 		TError,
 		MutationProps<TData, TError, TParams>,
 		MutationContext<TData>
@@ -445,7 +445,7 @@ export function createMutateAsyncFn<
 
 function createPublishEvent(
 	resolvedProps: ResolvedMutationProps<any, any, any>,
-	data: UpdateResult<any>,
+	data: UpdateOneResult<any>,
 ): Publish.EmitEvent<PublishPayload> {
 	const payload = createPublishPayloadByOne(resolvedProps, data)
 	const meta = createPublishMeta(resolvedProps)
@@ -490,7 +490,7 @@ function resolveProps<
 >(
 	propsFromProps: Props<TData, TError, TParams> | undefined,
 	propsFromFn: MutationProps<TData, TError, TParams>,
-): OverrideProperties<MutationProps<TData, TError, TParams>, UpdateProps<TParams>> {
+): OverrideProperties<MutationProps<TData, TError, TParams>, UpdateOneProps<TParams>> {
 	const props = {
 		...propsFromProps,
 		...propsFromFn,
@@ -524,7 +524,7 @@ function updateCache<
 			{ queryKey: genBaseGetListQueryKey({ props }) },
 			typeof listOptimisticUpdate === 'function'
 				? createOptimisticUpdaterFn(listOptimisticUpdate, props.params, props.id)
-				: createModifyListItemUpdaterFn<TData, TParams, TPageParam, UpdateProps<TParams>['id']>(props.id, props.params),
+				: createModifyListItemUpdaterFn<TData, TParams, TPageParam, UpdateOneProps<TParams>['id']>(props.id, props.params),
 		)
 	}
 	if (shouldApplyOptimisticUpdate(manyOptimisticUpdate)) {
@@ -532,7 +532,7 @@ function updateCache<
 			{ queryKey: genBaseGetManyQueryKey({ props }) },
 			typeof manyOptimisticUpdate === 'function'
 				? createOptimisticUpdaterFn(manyOptimisticUpdate, props.params, props.id)
-				: createModifyManyUpdaterFn<TData, TParams, UpdateProps<TParams>['id']>(props.id, props.params),
+				: createModifyManyUpdaterFn<TData, TParams, UpdateOneProps<TParams>['id']>(props.id, props.params),
 		)
 	}
 	if (shouldApplyOptimisticUpdate(oneOptimisticUpdate)) {
@@ -550,7 +550,7 @@ function dispatchSuccessNotify<
 >(
 	notify: Notify.Fn,
 	translate: Translate.Fn<any>,
-	data: UpdateResult<TData>,
+	data: UpdateOneResult<TData>,
 	resolvedProps: ResolvedMutationProps<TData, any, any>,
 ): void {
 	notify(

--- a/packages/svelte/src/query/create.svelte.ts
+++ b/packages/svelte/src/query/create.svelte.ts
@@ -1,4 +1,4 @@
-import type { BaseRecord, CreateResult, Params } from '@ginjou/core'
+import type { BaseRecord, CreateOneResult, Params } from '@ginjou/core'
 import type { CreateMutationResult } from '@tanstack/svelte-query'
 import type { OverrideProperties, Simplify } from 'type-fest'
 import type { UseCheckErrorContext } from '../auth'
@@ -41,7 +41,7 @@ export type UseCreateOneResult<
 	TParams extends Params,
 > = OverrideProperties<
 	CreateMutationResult<
-		CreateResult<TData>,
+		CreateOneResult<TData>,
 		TError,
 		CreateOne.MutationProps<TData, TError, TParams>,
 		any
@@ -88,7 +88,7 @@ export function useCreateOne<
 		onError: (...args) => resolvedProps?.mutationOptions?.onError?.(...args),
 	})
 
-	const mutation = createMutation<CreateResult<TData>, TError, CreateOne.MutationProps<TData, TError, TParams>>(
+	const mutation = createMutation<CreateOneResult<TData>, TError, CreateOne.MutationProps<TData, TError, TParams>>(
 		() => ({
 			...resolvedProps?.mutationOptions,
 			mutationFn,

--- a/packages/svelte/src/query/update.svelte.ts
+++ b/packages/svelte/src/query/update.svelte.ts
@@ -1,4 +1,4 @@
-import type { BaseRecord, Params, UpdateResult } from '@ginjou/core'
+import type { BaseRecord, Params, UpdateOneResult } from '@ginjou/core'
 import type { CreateMutationResult } from '@tanstack/svelte-query'
 import type { OverrideProperties, Simplify } from 'type-fest'
 import type { UseCheckErrorContext } from '../auth'
@@ -41,7 +41,7 @@ export type UseUpdateOneResult<
 	TParams extends Params,
 > = OverrideProperties<
 	CreateMutationResult<
-		UpdateResult<TData>,
+		UpdateOneResult<TData>,
 		TError,
 		UpdateOne.MutationProps<TData, TError, TParams>,
 		UpdateOne.MutationContext<TData>
@@ -104,7 +104,7 @@ export function useUpdateOne<
 	})
 
 	const mutation = createMutation<
-		UpdateResult<TData>,
+		UpdateOneResult<TData>,
 		TError,
 		UpdateOne.MutationProps<TData, TError, TParams>,
 		UpdateOne.MutationContext<TData>

--- a/packages/vue/src/query/create.ts
+++ b/packages/vue/src/query/create.ts
@@ -1,4 +1,4 @@
-import type { BaseRecord, CreateResult, Params } from '@ginjou/core'
+import type { BaseRecord, CreateOneResult, Params } from '@ginjou/core'
 import type { UseMutationReturnType } from '@tanstack/vue-query'
 import type { OverrideProperties, Simplify } from 'type-fest'
 import type { UseCheckErrorContext } from '../auth'
@@ -42,7 +42,7 @@ export type UseCreateOneResult<
 	TParams extends Params,
 > = OverrideProperties<
 	UseMutationReturnType<
-		CreateResult<TData>,
+		CreateOneResult<TData>,
 		TError,
 		CreateOne.MutationProps<TData, TError, TParams>,
 		any
@@ -88,7 +88,7 @@ export function useCreateOne<
 		onError: unref(props?.mutationOptions)?.onError,
 	})
 
-	const mutation = useMutation<CreateResult<TData>, TError, CreateOne.MutationProps<TData, TError, TParams>, any>(
+	const mutation = useMutation<CreateOneResult<TData>, TError, CreateOne.MutationProps<TData, TError, TParams>, any>(
 		computed(() => ({
 			...unref(props?.mutationOptions),
 			mutationFn,

--- a/packages/vue/src/query/update.ts
+++ b/packages/vue/src/query/update.ts
@@ -1,4 +1,4 @@
-import type { BaseRecord, Params, UpdateResult } from '@ginjou/core'
+import type { BaseRecord, Params, UpdateOneResult } from '@ginjou/core'
 import type { UseMutationReturnType } from '@tanstack/vue-query'
 import type { OverrideProperties, Simplify } from 'type-fest'
 import type { UseCheckErrorContext } from '../auth'
@@ -42,7 +42,7 @@ export type UseUpdateOneResult<
 	TParams extends Params,
 > = OverrideProperties<
 	UseMutationReturnType<
-		UpdateResult<TData>,
+		UpdateOneResult<TData>,
 		TError,
 		UpdateOne.MutationProps<TData, TError, TParams>,
 		UpdateOne.MutationContext<TData>
@@ -103,7 +103,7 @@ export function useUpdateOne<
 		onError: (...args) => unref(props?.mutationOptions)?.onError?.(...args),
 	})
 
-	const mutation = useMutation<UpdateResult<TData>, TError, UpdateOne.MutationProps<TData, TError, TParams>, UpdateOne.MutationContext<TData>>(computed(() => ({
+	const mutation = useMutation<UpdateOneResult<TData>, TError, UpdateOne.MutationProps<TData, TError, TParams>, UpdateOne.MutationContext<TData>>(computed(() => ({
 		...unref(props?.mutationOptions),
 		mutationFn,
 		onMutate: handleMutate,


### PR DESCRIPTION
## Summary

- Introduce `CreateOne` and `UpdateOne` aliases.
- Align consumers with the single-record naming.

## Why

Single-record types were inconsistent with other APIs.

## Validation

- Typechecks passed
- 46 tests passed
- ESLint passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed single-record create and update result contracts for clearer, more specific API naming.
  * Updated create and update operations across core controllers, queries, invalidation, publishing, and framework hooks.
  * No runtime behavior changes are expected.

* **Tests**
  * Updated controller test fixtures and typings to match the new contract names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->