### PR TITLE
refactor(core): align can-access type names

### DIFF
--- a/packages/core/src/authz/authz.ts
+++ b/packages/core/src/authz/authz.ts
@@ -13,7 +13,7 @@ export type GetPermissionsFn<
 	params?: TParams,
 ) => Promise<GetPermissionsResult<TData>>
 
-export interface AccessCanParams {
+export interface CanAccessParams {
 	action: LiteralUnion<ResourceAction.TypeValues, string>
 	resource?: string
 	params?: {
@@ -23,17 +23,26 @@ export interface AccessCanParams {
 	meta?: Record<string, any>
 }
 
-export interface AccessCanResult {
+export interface CanAccessResult {
 	can: boolean
 	reason?: string
 }
 
-export type AccessCanFn = (
-	params: AccessCanParams,
-) => AccessCanResult | Promise<AccessCanResult>
+export type CanAccessFn = (
+	params: CanAccessParams,
+) => CanAccessResult | Promise<CanAccessResult>
+
+/** @deprecated Use `CanAccessParams` instead. */
+export type AccessCanParams = CanAccessParams
+
+/** @deprecated Use `CanAccessResult` instead. */
+export type AccessCanResult = CanAccessResult
+
+/** @deprecated Use `CanAccessFn` instead. */
+export type AccessCanFn = CanAccessFn
 
 export interface Authz {
-	access?: AccessCanFn
+	access?: CanAccessFn
 	getPermissions?: GetPermissionsFn<any, any>
 }
 

--- a/packages/core/src/authz/authz.ts
+++ b/packages/core/src/authz/authz.ts
@@ -32,15 +32,6 @@ export type CanAccessFn = (
 	params: CanAccessParams,
 ) => CanAccessResult | Promise<CanAccessResult>
 
-/** @deprecated Use `CanAccessParams` instead. */
-export type AccessCanParams = CanAccessParams
-
-/** @deprecated Use `CanAccessResult` instead. */
-export type AccessCanResult = CanAccessResult
-
-/** @deprecated Use `CanAccessFn` instead. */
-export type AccessCanFn = CanAccessFn
-
 export interface Authz {
 	access?: CanAccessFn
 	getPermissions?: GetPermissionsFn<any, any>

--- a/packages/core/src/authz/can.test.ts
+++ b/packages/core/src/authz/can.test.ts
@@ -1,11 +1,11 @@
 import type { Query } from '@tanstack/query-core'
-import type { AccessCanParams, Authz } from './authz'
+import type { Authz, CanAccessParams } from './authz'
 import { describe, expect, it, vi } from 'vitest'
 import { createQueryEnabledFn, createQueryFn, createQueryKey } from './can'
 
 describe('createQueryKey', () => {
 	it('should return a query key with all params', () => {
-		const params: AccessCanParams = {
+		const params: CanAccessParams = {
 			resource: 'article',
 			action: 'create',
 			params: {
@@ -20,7 +20,7 @@ describe('createQueryKey', () => {
 	})
 
 	it('should filter out null or undefined params', () => {
-		const params: AccessCanParams = {
+		const params: CanAccessParams = {
 			resource: 'article',
 			action: 'create',
 		}
@@ -34,7 +34,7 @@ describe('createQueryFn', () => {
 		const authz: Authz = {
 			access: vi.fn().mockResolvedValue({ can: true }),
 		}
-		const params: AccessCanParams = {
+		const params: CanAccessParams = {
 			resource: 'article',
 			action: 'create',
 		}
@@ -45,7 +45,7 @@ describe('createQueryFn', () => {
 
 	it('should return default access can result when authz.access is not available', async () => {
 		const authz: Authz = {}
-		const params: AccessCanParams = {
+		const params: CanAccessParams = {
 			resource: 'article',
 			action: 'create',
 		}
@@ -55,7 +55,7 @@ describe('createQueryFn', () => {
 	})
 
 	it('should return default access can result when authz is not available', async () => {
-		const params: AccessCanParams = {
+		const params: CanAccessParams = {
 			resource: 'article',
 			action: 'create',
 		}

--- a/packages/core/src/authz/can.ts
+++ b/packages/core/src/authz/can.ts
@@ -2,18 +2,18 @@ import type { QueryFunction, QueryKey, QueryObserverOptions } from '@tanstack/qu
 import type { QueryCallbacks } from 'tanstack-query-callbacks'
 import type { Simplify } from 'type-fest'
 import type { OriginQueryEnabledFn } from '../utils/query'
-import type { AccessCanParams, AccessCanResult, Authz } from './authz'
+import type { Authz, CanAccessParams, CanAccessResult } from './authz'
 import { resolveQueryEnableds } from '../utils/query'
 
 export type QueryOptions<
 	TError,
 > = Simplify<
 	& QueryObserverOptions<
-		AccessCanResult,
+		CanAccessResult,
 		TError
 	>
 	& QueryCallbacks<
-		AccessCanResult,
+		CanAccessResult,
 		TError
 	>
 >
@@ -21,7 +21,7 @@ export type QueryOptions<
 export type Props<
 	TError,
 > = Simplify<
-	& AccessCanParams
+	& CanAccessParams
 	& {
 		queryOptions?: Omit<
 			QueryOptions<TError>,
@@ -33,7 +33,7 @@ export type Props<
 >
 
 export interface CreateQueryKeyProps {
-	params?: AccessCanParams
+	params?: CanAccessParams
 }
 
 export function createQueryKey(
@@ -53,10 +53,10 @@ export function createQueryKey(
 
 export interface CreateQueryFnProps {
 	authz: Authz | undefined
-	getParams: () => AccessCanParams
+	getParams: () => CanAccessParams
 }
 
-const DEFAULT_ACCESS_CAN_RESULT: AccessCanResult = {
+const DEFAULT_CAN_ACCESS_RESULT: CanAccessResult = {
 	can: true,
 }
 
@@ -65,11 +65,11 @@ export function createQueryFn(
 		authz,
 		getParams,
 	}: CreateQueryFnProps,
-): QueryFunction<AccessCanResult> {
+): QueryFunction<CanAccessResult> {
 	return async function queryFn() {
 		const params = getParams()
 
-		return authz?.access?.(params) ?? DEFAULT_ACCESS_CAN_RESULT
+		return authz?.access?.(params) ?? DEFAULT_CAN_ACCESS_RESULT
 	}
 }
 
@@ -87,7 +87,7 @@ export function createQueryEnabledFn<
 		getAuthz,
 		getEnabled,
 	}: CreateQueryEnabledFnProps<TError>,
-): OriginQueryEnabledFn<AccessCanResult, TError> {
+): OriginQueryEnabledFn<CanAccessResult, TError> {
 	return function enabled(
 		query,
 	) {

--- a/packages/svelte/src/authz/can.svelte.ts
+++ b/packages/svelte/src/authz/can.svelte.ts
@@ -1,4 +1,4 @@
-import type { AccessCanParams, AccessCanResult } from '@ginjou/core'
+import type { CanAccessParams, CanAccessResult } from '@ginjou/core'
 import type { CreateQueryResult } from '@tanstack/svelte-query'
 import type { Simplify } from 'type-fest'
 import type { UseQueryClientContextProps } from '../query'
@@ -25,7 +25,7 @@ export type UseCanAccessContext = Simplify<
 export type UseCanAccessResult<
 	TError,
 > = CreateQueryResult<
-	AccessCanResult,
+	CanAccessResult,
 	TError
 >
 
@@ -39,7 +39,7 @@ export function useCanAccess<
 	const queryClient = useQueryClientContext(context)
 
 	const resolvedProps = $derived(extract(props))
-	const params = $derived.by((): AccessCanParams => ({
+	const params = $derived.by((): CanAccessParams => ({
 		action: resolvedProps.action,
 		resource: resolvedProps.resource,
 		params: resolvedProps.params,
@@ -58,7 +58,7 @@ export function useCanAccess<
 		})
 	})
 
-	const query = createQuery<AccessCanResult, TError>(
+	const query = createQuery<CanAccessResult, TError>(
 		() => ({
 			...resolvedProps.queryOptions,
 			queryKey,
@@ -74,7 +74,7 @@ export function useCanAccess<
 	const handleError: NonNullable<CanAccess.QueryOptions<TError>['onError']> = (...args) =>
 		resolvedProps.queryOptions?.onError?.(...args)
 
-	useQueryCallbacks<AccessCanResult, TError>(() => ({
+	useQueryCallbacks<CanAccessResult, TError>(() => ({
 		queryKey,
 		queryClient,
 		onSuccess: handleSuccess,

--- a/packages/vue/src/authz/can.ts
+++ b/packages/vue/src/authz/can.ts
@@ -1,4 +1,4 @@
-import type { AccessCanParams, AccessCanResult } from '@ginjou/core'
+import type { CanAccessParams, CanAccessResult } from '@ginjou/core'
 import type { UseQueryReturnType } from '@tanstack/vue-query'
 import type { Simplify } from 'type-fest'
 import type { UseQueryClientContextProps } from '../query'
@@ -25,7 +25,7 @@ export type UseCanAccessContext = Simplify<
 export type UseCanAccessResult<
 	TError,
 > = Simplify<
-	& UseQueryReturnType<AccessCanResult, TError>
+	& UseQueryReturnType<CanAccessResult, TError>
 >
 
 export function useCanAccess<
@@ -37,7 +37,7 @@ export function useCanAccess<
 	const authz = useAuthzContext({ ...context, strict: true })
 	const queryClient = useQueryClientContext(context)
 
-	const params = computed<AccessCanParams>(() => {
+	const params = computed<CanAccessParams>(() => {
 		return {
 			action: unref(props.action),
 			resource: unref(props.resource),
@@ -60,7 +60,7 @@ export function useCanAccess<
 			getEnabled: () => queryOptions?.enabled,
 		})
 	})
-	const query = useQuery<AccessCanResult, TError>(
+	const query = useQuery<CanAccessResult, TError>(
 		computed(() => ({
 			...unref(props.queryOptions),
 			queryKey,
@@ -70,7 +70,7 @@ export function useCanAccess<
 		})),
 		queryClient,
 	)
-	useQueryCallbacks<AccessCanResult, TError>({
+	useQueryCallbacks<CanAccessResult, TError>({
 		queryKey,
 		queryClient,
 		onSuccess: (...args) => unref(props?.queryOptions)?.onSuccess?.(...args),

--- a/skills/ginjou/references/authorization/svelte.md
+++ b/skills/ginjou/references/authorization/svelte.md
@@ -6,7 +6,7 @@ Access-control wiring and composables for Svelte 5. See [Authorization](https://
 
 ```ts
 interface Authz {
-	access?: AccessCanFn
+	access?: CanAccessFn
 	getPermissions?: GetPermissionsFn<any, any>
 }
 ```

--- a/skills/ginjou/references/authorization/vue.md
+++ b/skills/ginjou/references/authorization/vue.md
@@ -6,7 +6,7 @@ Use this reference for Vue authz wiring and authz composables. See [Authorizatio
 
 ```ts
 interface Authz {
-	access?: AccessCanFn
+	access?: CanAccessFn
 	getPermissions?: GetPermissionsFn<any, any>
 }
 ```


### PR DESCRIPTION
## Summary

- Add consistently ordered `CanAccess` aliases.
- Keep the access method compatible.

## Why

Public type word order differed.

## Validation

- Typechecks passed
- 13 tests passed
- ESLint passed