### PR TITLE
refactor(core): standardize query key aliases

### DIFF
--- a/packages/core/src/auth/invalidate.ts
+++ b/packages/core/src/auth/invalidate.ts
@@ -1,18 +1,18 @@
 import type { QueryClient } from '@tanstack/query-core'
-import { createQueryKey as createCanAccessQueryKey } from '../authz/can'
-import { createQueryKey as createPermissionsQueryKey } from '../authz/permissions'
-import { createQueryKey as createCheckQueryKey } from './check'
-import { createQueryKey as createIdentityQueryKey } from './identity'
+import { createQueryKey as genCanAccessQueryKey } from '../authz/can'
+import { createQueryKey as genPermissionsQueryKey } from '../authz/permissions'
+import { createQueryKey as genCheckQueryKey } from './check'
+import { createQueryKey as genIdentityQueryKey } from './identity'
 
 export async function triggerInvalidateAll(
 	queryClient: QueryClient,
 ): Promise<void> {
 	await Promise.all(
 		[
-			createCheckQueryKey(),
-			createIdentityQueryKey(),
-			createPermissionsQueryKey(),
-			createCanAccessQueryKey({}),
+			genCheckQueryKey(),
+			genIdentityQueryKey(),
+			genPermissionsQueryKey(),
+			genCanAccessQueryKey({}),
 		].map(key => queryClient.invalidateQueries(
 			{
 				queryKey: key,

--- a/packages/core/src/query/get-infinite-list.ts
+++ b/packages/core/src/query/get-infinite-list.ts
@@ -13,7 +13,7 @@ import { NotificationType } from '../notification'
 import { getErrorMessage } from '../utils/error'
 import { getQuery, resolveQueryEnableds } from '../utils/query'
 import { getFetcherFn, resolveFetcherProps } from './fetchers'
-import { createQueryKey as createGetOneQueryKey } from './get-one'
+import { createQueryKey as genGetOneQueryKey } from './get-one'
 import { resolveErrorNotifyParams, resolveSuccessNotifyParams } from './notify'
 
 export type QueryOptions<
@@ -376,7 +376,7 @@ function updateCache<
 			continue
 
 		queryClient.setQueryData<GetOneResult<TData>>(
-			createGetOneQueryKey({
+			genGetOneQueryKey({
 				props: { ...props, id: record.id },
 			}),
 			old => old ?? { data: record },

--- a/packages/core/src/query/get-list.ts
+++ b/packages/core/src/query/get-list.ts
@@ -16,9 +16,9 @@ import { SubscribeType } from '../realtime'
 import { getErrorMessage } from '../utils/error'
 import { getQuery, resolveQueryEnableds } from '../utils/query'
 import { getFetcherFn, resolveFetcherProps } from './fetchers'
-import { createQueryKey as createGetOneQueryKey } from './get-one'
+import { createQueryKey as genGetOneQueryKey } from './get-one'
 import { resolveErrorNotifyParams, resolveSuccessNotifyParams } from './notify'
-import { createQueryKey as createResourceQueryKey } from './resource'
+import { createQueryKey as genResourceQueryKey } from './resource'
 
 export type QueryOptions<
 	TData extends BaseRecord,
@@ -97,7 +97,7 @@ export function createBaseQueryKey(
 	}: CreateBaseQueryKeyProps,
 ): QueryKey {
 	return [
-		...createResourceQueryKey({ props }),
+		...genResourceQueryKey({ props }),
 		'getList',
 	]
 }
@@ -337,7 +337,7 @@ function updateCache<
 			continue
 
 		queryClient.setQueryData<GetOneResult<TData>>(
-			createGetOneQueryKey({
+			genGetOneQueryKey({
 				props: { ...props, id: record.id },
 			}),
 			old => old ?? { data: record },

--- a/packages/core/src/query/get-many.ts
+++ b/packages/core/src/query/get-many.ts
@@ -19,10 +19,10 @@ import { getErrorMessage } from '../utils/error'
 import { getQuery, resolveQueryEnableds } from '../utils/query'
 import { createAggregrateFn } from './aggregrate'
 import { getFetcherFn, getSafeFetcherFn, resolveFetcherProps } from './fetchers'
-import { createQueryKey as createGetOneQueryKey } from './get-one'
+import { createQueryKey as genGetOneQueryKey } from './get-one'
 import { fakeMany } from './helper'
 import { resolveErrorNotifyParams, resolveSuccessNotifyParams } from './notify'
-import { createQueryKey as createResourceQueryKey } from './resource'
+import { createQueryKey as genResourceQueryKey } from './resource'
 
 export type QueryOptions<
 	TData extends BaseRecord,
@@ -100,7 +100,7 @@ export function createBaseQueryKey(
 	}: CreateBaseQueryKeyProps,
 ): QueryKey {
 	return [
-		...createResourceQueryKey({ props }),
+		...genResourceQueryKey({ props }),
 		'getMany',
 	]
 }
@@ -407,7 +407,7 @@ function updateCache<
 			continue
 
 		queryClient.setQueryData<GetOneResult<TData>>(
-			createGetOneQueryKey({
+			genGetOneQueryKey({
 				props: { ...props, id: record.id },
 			}),
 			old => old ?? { data: record },
@@ -424,6 +424,6 @@ function findGetOneCached<
 	queryClient: QueryClient,
 ): GetOneResult<TResultData> | undefined {
 	const queryCache = queryClient.getQueryCache()
-	const queryHash = hashKey(createGetOneQueryKey({ props }))
+	const queryHash = hashKey(genGetOneQueryKey({ props }))
 	return queryCache.get<GetOneResult<TData>, TError, GetOneResult<TResultData>>(queryHash)?.state.data
 }

--- a/packages/core/src/query/get-one.ts
+++ b/packages/core/src/query/get-one.ts
@@ -16,7 +16,7 @@ import { getErrorMessage } from '../utils/error'
 import { getQuery, resolveQueryEnableds } from '../utils/query'
 import { getFetcherFn, resolveFetcherProps } from './fetchers'
 import { resolveErrorNotifyParams, resolveSuccessNotifyParams } from './notify'
-import { createQueryKey as createResourceQueryKey } from './resource'
+import { createQueryKey as genResourceQueryKey } from './resource'
 
 export type QueryOptions<
 	TData extends BaseRecord,
@@ -89,7 +89,7 @@ export function createQueryKey(
 	const { id, meta } = props
 
 	return [
-		...createResourceQueryKey({ props }),
+		...genResourceQueryKey({ props }),
 		'getOne',
 		id,
 		{ meta },


### PR DESCRIPTION
## Summary

- Standardize query-key alias names on `gen` while leaving public `create` behavior unchanged.

## Why

Internal aliases mixed `create` and `gen` terminology.

## Validation

- 400 tests
- Typecheck
- ESLint