### PR TITLE
fix: standardize runtime error messages

### DIFF
--- a/packages/core/src/query/get-many.ts
+++ b/packages/core/src/query/get-many.ts
@@ -383,7 +383,7 @@ const aggregExecGetMany = createAggregrateFn(
 
 			const args = value.args[0]
 			if (!args)
-				throw new Error('Panic')
+				throw new Error('[@ginjou/core] Cannot aggregate get-many requests because no request arguments were provided.')
 			args[0] = { ...args?.[0], ids }
 
 			result.push([

--- a/packages/vue/src/query/query-client.test.ts
+++ b/packages/vue/src/query/query-client.test.ts
@@ -5,6 +5,12 @@ import { mountSetup } from '../../test/mount'
 import { defineQueryClientContext, getQueryClients, setQueryClientDehydrateState } from './query-client'
 
 describe('query-client global pollution', () => {
+	it('rejects defining context outside setup', () => {
+		expect(() => defineQueryClientContext()).toThrowError(
+			'[@ginjou/vue] Cannot define query client context outside an active component. Call defineQueryClientContext() inside setup().',
+		)
+	})
+
 	// Two apps = two concurrent SSR requests sharing the same module.
 	// getQueryClients() must return only the client of the app it is asked about,
 	// otherwise request A dehydrates request B's data -> cross-request leak.

--- a/packages/vue/src/query/query-client.ts
+++ b/packages/vue/src/query/query-client.ts
@@ -19,7 +19,7 @@ export function defineQueryClientContext(
 ): QueryClient {
 	const instance = getCurrentInstance()
 	if (!instance)
-		throw new Error('defineQueryClientContext() is called when there is no active component')
+		throw new Error('[@ginjou/vue] Cannot define query client context outside an active component. Call defineQueryClientContext() inside setup().')
 
 	const key = useStableId()
 	const state = getState(instance.appContext.app)

--- a/packages/vue/src/utils/id.ts
+++ b/packages/vue/src/utils/id.ts
@@ -33,7 +33,7 @@ const AppIdCount = new WeakMap<App, number>()
 function useAppId(): string {
 	const instance = getCurrentInstance()
 	if (!instance)
-		throw new Error('useStableId() is called when there is no active component')
+		throw new Error('[@ginjou/vue] Cannot create a stable ID outside an active component. Call useStableId() inside setup().')
 
 	let count = AppIdCount.get(instance.appContext.app) ?? 0
 	++count

--- a/packages/with-rest-api/src/utils/filters.test.ts
+++ b/packages/with-rest-api/src/utils/filters.test.ts
@@ -15,14 +15,14 @@ describe('genFilters', () => {
 	it('should throw an error for "or" operator', () => {
 		const filters = [{ operator: FilterOperator.or, value: [] }] as any
 		expect(() => genFilters(filters)).toThrowError(
-			'[@ginjou/with-rest-api]: `operator: or` is not supported.',
+			'[@ginjou/with-rest-api] `operator: or` is not supported.',
 		)
 	})
 
 	it('should throw an error for "and" operator', () => {
 		const filters = [{ operator: FilterOperator.and, value: [] }] as any
 		expect(() => genFilters(filters)).toThrowError(
-			'[@ginjou/with-rest-api]: `operator: and` is not supported.',
+			'[@ginjou/with-rest-api] `operator: and` is not supported.',
 		)
 	})
 

--- a/packages/with-rest-api/src/utils/filters.ts
+++ b/packages/with-rest-api/src/utils/filters.ts
@@ -11,7 +11,7 @@ export function genFilters(
 	filters.forEach((filter) => {
 		if (isConditionalFilterOperator(filter.operator)) {
 			throw new Error(
-				`[@ginjou/with-rest-api]: \`operator: ${filter.operator}\` is not supported.`,
+				`[@ginjou/with-rest-api] \`operator: ${filter.operator}\` is not supported.`,
 			)
 		}
 


### PR DESCRIPTION
## Summary

- Make runtime errors branded and actionable, including the REST prefix.

## Why

Inconsistent messages made failures harder to trace.

## Validation

- 21 tests
- Core, Vue, and REST typechecks
- ESLint