### PR TITLE
test(integrations): add adapter smoke coverage

### DIFF
--- a/packages/with-supabase/src/auth.test.ts
+++ b/packages/with-supabase/src/auth.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createAuth } from './auth'
+
+describe('createAuth', () => {
+	it('dispatches password login to Supabase', async () => {
+		const signInWithPassword = vi.fn().mockResolvedValue({ error: null })
+		const auth = createAuth({
+			client: {
+				auth: { signInWithPassword },
+			} as any,
+		})
+		const params = {
+			email: 'test@example.com',
+			password: 'password',
+		}
+
+		await auth.login({ type: 'password', params })
+
+		expect(signInWithPassword).toHaveBeenCalledWith(params)
+	})
+})

--- a/packages/with-svelte-spa-router/src/location.test.ts
+++ b/packages/with-svelte-spa-router/src/location.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { buildPath, defaultParseQuery, defaultStringifyQuery } from './location'
+
+describe('buildPath', () => {
+	it('maps navigation while preserving the current query', () => {
+		expect(buildPath(
+			{ to: '/next', query: { page: 2 }, hash: 'results', keepQuery: true },
+			'/current',
+			'filter=active&page=1',
+			defaultParseQuery,
+			defaultStringifyQuery,
+		)).toBe('/next?filter=active&page=2#results')
+	})
+})

--- a/packages/with-svelte-spa-router/tsconfig.json
+++ b/packages/with-svelte-spa-router/tsconfig.json
@@ -1,7 +1,8 @@
 {
 	"references": [
 		{ "path": "./tsconfig.node.json" },
-		{ "path": "./tsconfig.app.json" }
+		{ "path": "./tsconfig.app.json" },
+		{ "path": "./tsconfig.test.json" }
 	],
 	"files": []
 }

--- a/packages/with-svelte-spa-router/tsconfig.test.json
+++ b/packages/with-svelte-spa-router/tsconfig.test.json
@@ -1,0 +1,18 @@
+{
+	"extends": "./tsconfig.app.json",
+	"compilerOptions": {
+		"lib": [],
+		"types": [
+			"node"
+		]
+	},
+	"references": [
+		{ "path": "../core/tsconfig.app.json" },
+		{ "path": "../svelte/tsconfig.app.json" }
+	],
+	"include": [
+		"src/**/*.ts",
+		"src/**/*.svelte.ts"
+	],
+	"exclude": []
+}

--- a/packages/with-vue-i18n/src/i18n.test.ts
+++ b/packages/with-vue-i18n/src/i18n.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createI18n } from './i18n'
+
+const mocks = vi.hoisted(() => ({
+	locale: { value: 'en' },
+	stop: vi.fn(),
+	t: vi.fn(),
+	watch: vi.fn(),
+}))
+
+vi.mock('vue-i18n', () => ({
+	useI18n: () => ({
+		locale: mocks.locale,
+		t: mocks.t,
+	}),
+}))
+
+vi.mock('vue-demi', () => ({
+	unref: (value: { value: unknown }) => value.value,
+	watch: mocks.watch,
+}))
+
+describe('createI18n', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		mocks.locale.value = 'en'
+		mocks.t.mockReturnValue('Hello')
+		mocks.watch.mockReturnValue(mocks.stop)
+	})
+
+	it('maps translation and locale changes', () => {
+		const i18n = createI18n()
+
+		expect(i18n.translate('hello', { name: 'Ginjou' })).toBe('Hello')
+		expect(mocks.t).toHaveBeenCalledWith('hello', { name: 'Ginjou' })
+		expect(i18n.getLocale()).toBe('en')
+
+		i18n.setLocale('zh-TW')
+		expect(mocks.locale.value).toBe('zh-TW')
+		expect(i18n.onChangeLocale(vi.fn())).toBe(mocks.stop)
+	})
+})

--- a/packages/with-vue-router/src/router.test.ts
+++ b/packages/with-vue-router/src/router.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createRouter } from './router'
+
+const mocks = vi.hoisted(() => ({
+	onBeforeRouteLeave: vi.fn(),
+	push: vi.fn(),
+	stop: vi.fn(),
+	watch: vi.fn(),
+}))
+
+vi.mock('vue-router', () => ({
+	onBeforeRouteLeave: mocks.onBeforeRouteLeave,
+	useRouter: () => ({
+		back: vi.fn(),
+		currentRoute: {
+			value: {
+				hash: '#current',
+				params: {},
+				path: '/current',
+				query: { page: '1' },
+			},
+		},
+		push: mocks.push,
+		resolve: vi.fn(),
+	}),
+}))
+
+vi.mock('vue-demi', () => ({
+	watch: mocks.watch,
+}))
+
+describe('createRouter', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		mocks.watch.mockReturnValue(mocks.stop)
+	})
+
+	it('maps navigation and registers its location cleanup', () => {
+		const router = createRouter()
+
+		router.go({ to: '/next', type: 'replace', keepQuery: true })
+		const cleanup = router.onChangeLocation(vi.fn())
+
+		expect(mocks.push).toHaveBeenCalledWith({
+			path: '/next',
+			query: { page: '1' },
+			replace: true,
+		})
+		expect(mocks.onBeforeRouteLeave).toHaveBeenCalledWith(mocks.stop)
+		expect(cleanup).toBe(mocks.stop)
+	})
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,9 +11,6 @@ export default defineConfig({
 			include: [
 				'packages/*/src/**/*',
 			],
-			exclude: [
-				'packages/with-svelte-spa-router/src/router.svelte.ts',
-			],
 		},
 		projects: [
 			'packages/*',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
 				'packages/*/src/**/*',
 			],
 			exclude: [
-				'packages/with-svelte-spa-router/**/*', // FIXME:
+				'packages/with-svelte-spa-router/src/router.svelte.ts',
 			],
 		},
 		projects: [


### PR DESCRIPTION
## Summary

- Add focused smoke tests for four adapters and narrow coverage gaps.

## Why

Integration entry points lacked basic execution coverage.

## Validation

- 4 tests
- Typechecks
- ESLint
- Coverage checked

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for Supabase password authentication.
  * Added tests for Svelte SPA Router query and hash preservation during navigation.
  * Added coverage for Vue i18n translations, locale changes, and cleanup.
  * Added tests for Vue Router navigation, query handling, and route cleanup.
  * Enabled coverage reporting for the Svelte SPA Router package.
* **Chores**
  * Added TypeScript test configuration for the Svelte SPA Router package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->