### PR TITLE
fix: separate infinite list query cache

### DIFF
--- a/packages/core/src/query/get-infinite-list.test.ts
+++ b/packages/core/src/query/get-infinite-list.test.ts
@@ -1,9 +1,22 @@
 import type { Query } from '@tanstack/query-core'
 import { QueryClient } from '@tanstack/query-core'
 import { describe, expect, it, vi } from 'vitest'
-import { createGetNextPageParamFn, createGetPreviousPageParamFn, createQueryEnabledFn } from './get-infinite-list'
+import { createGetNextPageParamFn, createGetPreviousPageParamFn, createQueryEnabledFn, createQueryKey } from './get-infinite-list'
 
 describe('get infinite list', () => {
+	it('creates a query key', () => {
+		const props = {
+			fetcherName: 'default',
+			resource: 'posts',
+			pagination: { current: 1, perPage: 10 },
+			sorters: undefined,
+			filters: undefined,
+			meta: undefined,
+		}
+
+		expect(createQueryKey({ props })).toEqual(['default', 'posts', 'getInfiniteList', { pagination: props.pagination, sorters: undefined, filters: undefined, meta: undefined }])
+	})
+
 	describe('for getNextPageParam', () => {
 		it('should get undefine when deafult', () => {
 			const getNextPageParam = createGetNextPageParamFn()

--- a/packages/core/src/query/get-infinite-list.test.ts
+++ b/packages/core/src/query/get-infinite-list.test.ts
@@ -9,12 +9,13 @@ describe('get infinite list', () => {
 			fetcherName: 'default',
 			resource: 'posts',
 			pagination: { current: 1, perPage: 10 },
-			sorters: undefined,
-			filters: undefined,
-			meta: undefined,
+			sorters: [{ field: 'title', order: 'asc' as const }],
+			filters: [{ field: 'published', operator: 'eq' as const, value: true }],
+			meta: { source: 'test' },
 		}
 
-		expect(createQueryKey({ props })).toEqual(['default', 'posts', 'getInfiniteList', { pagination: props.pagination, sorters: undefined, filters: undefined, meta: undefined }])
+		expect(createQueryKey({ props })).toEqual(['default', 'posts', 'getInfiniteList', { pagination: props.pagination, sorters: props.sorters, filters: props.filters, meta: props.meta }])
+		expect(createQueryKey({ props: { fetcherName: 'default', resource: 'posts' } as typeof props })).toEqual(['default', 'posts', 'getInfiniteList'])
 	})
 
 	describe('for getNextPageParam', () => {

--- a/packages/core/src/query/get-infinite-list.ts
+++ b/packages/core/src/query/get-infinite-list.ts
@@ -9,12 +9,14 @@ import type { BaseRecord, GetInfiniteListResult, GetListFn, GetListProps, GetOne
 import type { FetcherProps, Fetchers, ResolvedFetcherProps } from './fetchers'
 import type { NotifyProps } from './notify'
 import type { RealtimeProps } from './realtime'
+import type { ResourceQueryProps } from './resource'
 import { NotificationType } from '../notification'
 import { getErrorMessage } from '../utils/error'
 import { getQuery, resolveQueryEnableds } from '../utils/query'
 import { getFetcherFn, resolveFetcherProps } from './fetchers'
 import { createQueryKey as genGetOneQueryKey } from './get-one'
 import { resolveErrorNotifyParams, resolveSuccessNotifyParams } from './notify'
+import { createQueryKey as genResourceQueryKey } from './resource'
 
 export type QueryOptions<
 	TData extends BaseRecord,
@@ -95,6 +97,49 @@ export type Props<
 		>
 	}
 >
+
+export interface CreateBaseQueryKeyProps {
+	props: ResourceQueryProps
+}
+
+export function createBaseQueryKey(
+	{
+		props,
+	}: CreateBaseQueryKeyProps,
+): QueryKey {
+	return [
+		...genResourceQueryKey({ props }),
+		'getInfiniteList',
+	]
+}
+
+export interface CreateQueryKeyProps<
+	TPageParam,
+> {
+	props: ResolvedQueryProps<TPageParam>
+}
+
+export function createQueryKey<
+	TPageParam,
+>(
+	{
+		props,
+	}: CreateQueryKeyProps<TPageParam>,
+): QueryKey {
+	const { pagination, sorters, filters, meta } = props
+
+	return [
+		...createBaseQueryKey({ props }),
+		[pagination, sorters, filters, meta].every(item => item == null)
+			? undefined
+			: {
+					pagination,
+					sorters,
+					filters,
+					meta,
+				},
+	].filter(Boolean)
+}
 
 export interface CreateQueryFnProps<
 	TPageParam,

--- a/packages/core/src/query/invalidate.test.ts
+++ b/packages/core/src/query/invalidate.test.ts
@@ -1,0 +1,26 @@
+import { QueryClient } from '@tanstack/query-core'
+import { describe, expect, it, vi } from 'vitest'
+import { InvalidateTarget, triggerInvalidate } from './invalidate'
+
+describe('triggerInvalidate', () => {
+	it('invalidates normal and infinite list caches together', async () => {
+		const queryClient = new QueryClient()
+		const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries')
+
+		await triggerInvalidate(
+			{ fetcherName: 'default', resource: 'posts', meta: { scope: 'admin' } } as any,
+			InvalidateTarget.List,
+			undefined,
+			queryClient,
+		)
+
+		expect(invalidateQueries).toHaveBeenCalledWith(
+			{ queryKey: ['default', 'posts', 'getList'], type: 'all', refetchType: 'active' },
+			{ cancelRefetch: false },
+		)
+		expect(invalidateQueries).toHaveBeenCalledWith(
+			{ queryKey: ['default', 'posts', 'getInfiniteList'], type: 'all', refetchType: 'active' },
+			{ cancelRefetch: false },
+		)
+	})
+})

--- a/packages/core/src/query/invalidate.ts
+++ b/packages/core/src/query/invalidate.ts
@@ -1,7 +1,8 @@
 import type { InvalidateOptions, InvalidateQueryFilters, QueryClient } from '@tanstack/query-core'
 import type { SetRequired, Simplify, ValueOf } from 'type-fest'
 import type { BaseRecord, CreateManyResult, CreateOneResult, DeleteManyResult, DeleteOneResult, GetManyResult, GetOneResult, RecordKey, UpdateManyResult, UpdateOneResult } from './fetcher'
-import { createQueryKey as genGetListQueryKey } from './get-list'
+import { createBaseQueryKey as genBaseGetInfiniteListQueryKey } from './get-infinite-list'
+import { createBaseQueryKey as genBaseGetListQueryKey } from './get-list'
 import { createQueryKey as genGetManyQueryKey } from './get-many'
 import { createQueryKey as genGetOneQueryKey } from './get-one'
 
@@ -224,13 +225,22 @@ export async function triggerInvalidate<
 			)
 			break
 		case InvalidateTarget.List:
-			await queryClient.invalidateQueries(
-				{
-					queryKey: genGetListQueryKey({ props }),
-					...invalidateFilters,
-				},
-				invalidateOptions,
-			)
+			await Promise.all([
+				queryClient.invalidateQueries(
+					{
+						queryKey: genBaseGetListQueryKey({ props }),
+						...invalidateFilters,
+					},
+					invalidateOptions,
+				),
+				queryClient.invalidateQueries(
+					{
+						queryKey: genBaseGetInfiniteListQueryKey({ props }),
+						...invalidateFilters,
+					},
+					invalidateOptions,
+				),
+			])
 			break
 		case InvalidateTarget.Many: {
 			const { resource, ids } = props

--- a/packages/svelte/src/query/get-infinite-list.svelte.test.ts
+++ b/packages/svelte/src/query/get-infinite-list.svelte.test.ts
@@ -34,10 +34,10 @@ vi.mock('@ginjou/core', () => ({
 		Any: 'any',
 	},
 	GetList: {
-		createQueryKey: mocks.createQueryKey,
 		getSubscribeParams: mocks.getSubscribeParams,
 	},
 	GetInfiniteList: {
+		createQueryKey: mocks.createQueryKey,
 		createErrorHandler: mocks.createErrorHandler,
 		createGetNextPageParamFn: mocks.createGetNextPageParamFn,
 		createGetPreviousPageParamFn: mocks.createGetPreviousPageParamFn,

--- a/packages/svelte/src/query/get-infinite-list.svelte.ts
+++ b/packages/svelte/src/query/get-infinite-list.svelte.ts
@@ -74,7 +74,7 @@ export function useGetInfiniteList<
 		filters: extract(resolvedProps.filters),
 		meta: extract(resolvedProps.meta),
 	}))
-	const queryKey = $derived.by(() => GetList.createQueryKey<TPageParam>({
+	const queryKey = $derived.by(() => GetInfiniteList.createQueryKey<TPageParam>({
 		props: queryProps,
 	}))
 	const initialPageParam = $derived.by(() => GetInfiniteList.getInitialPageParam({

--- a/packages/vue/src/query/get-infinite-list.ts
+++ b/packages/vue/src/query/get-infinite-list.ts
@@ -77,7 +77,7 @@ export function useGetInfiniteList<
 		filters: unref(props.filters),
 		meta: unref(props.meta),
 	}))
-	const queryKey = computed(() => GetList.createQueryKey<TPageParam>({
+	const queryKey = computed(() => GetInfiniteList.createQueryKey<TPageParam>({
 		props: unref(queryProps),
 	}))
 	const initialPageParam = computed(() => GetInfiniteList.getInitialPageParam({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache invalidation so both standard and infinite lists update correctly after changes.
  * Fixed infinite-list cache tracking across Svelte and Vue integrations.
  * Improved cache separation for infinite lists using pagination, sorting, filtering, and metadata settings.

* **Tests**
  * Added coverage for infinite-list query keys and simultaneous invalidation of standard and infinite-list caches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->